### PR TITLE
Capacitive touch sensing

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -31,20 +31,137 @@ macro_rules! dump_hex {
     };
 }
 
+fn autocal (adc: & hal::raw::ADC0) {
+    // Calibration + offset trimming
+    adc.ofstrim.write(|w| unsafe {
+        w.ofstrim_a().bits(10)
+        .ofstrim_b().bits(10)
+    });
+
+    // Request calibration
+    adc.ctrl.modify(|_,w| {w.cal_req().set_bit()});
+
+    // wait for auto-cal to be ready.
+    while (!adc.gcc[0].read().rdy().bits()) || (!adc.gcc[1].read().rdy().bits()) {
+    }
+
+    let gain_a = adc.gcc[0].read().gain_cal().bits();
+    let gain_b = adc.gcc[1].read().gain_cal().bits();
+
+    let gcr_a = (((gain_a as u32) << 16) / (0x1FFFFu32 - gain_a as u32 )) as u16;
+    let gcr_b = (((gain_b as u32) << 16) / (0x1FFFFu32 - gain_b as u32 )) as u16;
+
+    adc.gcr[0].write(|w| unsafe {w.gcalr().bits(gcr_a)});
+    adc.gcr[1].write(|w| unsafe {w.gcalr().bits(gcr_b)});
+
+    adc.gcr[0].write(|w| {w.rdy().set_bit()});
+    adc.gcr[1].write(|w| {w.rdy().set_bit()});
+
+    while !adc.stat.read().cal_rdy().bits() {
+    }
+}
+
 #[entry]
 fn main() -> ! {
 
-    dbg!("Hello PUF");
+    heprintln!("Hello ADC").unwrap();
 
     // Get pointer to all device peripherals.
-    let dp = hal::raw::Peripherals::take().unwrap();
-    let mut syscon = hal::Syscon::from(dp.SYSCON);
+    let mut hal = hal::new();
+
+    let clocks = hal::ClockRequirements::default()
+        .system_frequency(12.mhz())
+        .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
+        .unwrap();
 
     // Acquire PUF in an enabled state
-    let puf = hal::Adc::from(dp.ADC0).enabled(&mut syscon);
+    let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
+    // let adc = hal::Adc::from(dp.ADC0).enabled(&mut syscon);
+
+    let adc = adc.release();
+
+    adc.ctrl.write(|w| {
+        w.dozen().set_bit()
+        .cal_avgs().cal_avgs_7()
+    });
+
+    adc.cfg.write(|w| unsafe {
+        w.pwren().set_bit()
+        .pudly().bits(0x80)
+        .refsel().refsel_1()
+        .pwrsel().pwrsel_1()
+        .tprictrl().bits(0)
+    });
 
 
+    // No pause for now, but could be interesting
+    adc.pause.write(|w| unsafe {w.bits(0)});
 
+    // Set 0 for watermark
+    adc.fctrl[0].write(|w| unsafe{w.fwmark().bits(0)});
+    adc.fctrl[1].write(|w| unsafe{w.fwmark().bits(0)});
+
+
+    // turn on!
+    adc.ctrl.modify(|_, w| {w.adcen().set_bit()});
+
+    heprintln!("Auto calibrating..");
+    autocal(& adc);
+
+    // channel 13 (1V ref), single ended A, high res
+    adc.cmdl1.write(|w| unsafe {  w.adch().bits(13)
+                                .ctype().ctype_0()  
+                                .mode().mode_1()
+                                } );
+
+    adc.cmdh1.write(|w| unsafe { w.avgs().avgs_5()      // average 2^5 samples
+                                .cmpen().bits(0)        // disable compare
+                                .loop_().bits(0)         // no loop
+                                .next().bits(0)         // no next command
+                            } );
+
+    adc.tctrl[0].write(|w| unsafe {
+        w.hten().set_bit()
+        .fifo_sel_a().fifo_sel_a_0()
+        .fifo_sel_b().fifo_sel_b_0()
+        .tcmd().bits(1)
+    });
+
+    heprintln!("ADC CTRL. {:02X}", adc.ctrl.read().bits()).unwrap();
+    heprintln!("ADC  CFG. {:02X}", adc.cfg.read().bits()).unwrap();
+    heprintln!("ADC stat: {:02X}", adc.stat.read().bits()).unwrap();
+
+    // SW trigger the trigger event 0
+    adc.swtrig.write(|w| unsafe {w.bits(1)});
+
+    dbg!("triggered");
+
+    let count0 = adc.fctrl[0].read().fcount().bits();
+
+    heprintln!("FIFO0 conversions {}", count0).unwrap();
+
+    let result = adc.resfifo[0].read().bits();
+    let valid = result & 0x80000000;
+    let sample = (result & 0xffff) as u16;
+   
+    if valid != 0 {
+        heprintln!("sample = {:02x}", sample).unwrap();
+    } else {
+        heprintln!("No result from ADC!").unwrap();
+    }
+
+    for i in 0..10 {
+
+        adc.swtrig.write(|w| unsafe {w.bits(1)});
+        while adc.fctrl[0].read().fcount().bits() == 0 {
+        }
+        let result = adc.resfifo[0].read().bits();
+        assert!( (result & 0x80000000) != 0 );
+        let sample = (result & 0xffff) as u16;
+        heprintln!("sample{} = {:02x}", i, sample).unwrap();
+    }
+
+    heprintln!("looping").unwrap();
     loop {
 
     }

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,51 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_semihosting;  // 4004 bytes
+// extern crate panic_halt; // 672 bytes
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::dbg;
+use cortex_m_semihosting::heprintln;
+use cortex_m_semihosting::heprint;
+
+use lpc55_hal as hal;
+use hal::prelude::*;
+
+/// PUF error
+#[derive(Debug)]
+pub enum State {
+    NotEnrolled,
+    Enrolled = 0x7533ff04,
+}
+
+macro_rules! dump_hex {
+    ($array:expr, $length:expr ) => {
+
+        heprint!("{:?} = ", stringify!($array)).unwrap();
+        for i in 0..$length {
+            heprint!("{:02X}", $array[i]).unwrap();
+        }
+        heprintln!("").unwrap();
+
+    };
+}
+
+#[entry]
+fn main() -> ! {
+
+    dbg!("Hello PUF");
+
+    // Get pointer to all device peripherals.
+    let dp = hal::raw::Peripherals::take().unwrap();
+    let mut syscon = hal::Syscon::from(dp.SYSCON);
+
+    // Acquire PUF in an enabled state
+    let puf = hal::Adc::from(dp.ADC0).enabled(&mut syscon);
+
+
+
+    loop {
+
+    }
+}

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -7,29 +7,9 @@ extern crate panic_semihosting;  // 4004 bytes
 use cortex_m_rt::entry;
 use cortex_m_semihosting::dbg;
 use cortex_m_semihosting::heprintln;
-use cortex_m_semihosting::heprint;
 
 use lpc55_hal as hal;
 use hal::prelude::*;
-
-/// PUF error
-#[derive(Debug)]
-pub enum State {
-    NotEnrolled,
-    Enrolled = 0x7533ff04,
-}
-
-macro_rules! dump_hex {
-    ($array:expr, $length:expr ) => {
-
-        heprint!("{:?} = ", stringify!($array)).unwrap();
-        for i in 0..$length {
-            heprint!("{:02X}", $array[i]).unwrap();
-        }
-        heprintln!("").unwrap();
-
-    };
-}
 
 fn autocal (adc: & hal::raw::ADC0) {
     // Calibration + offset trimming
@@ -69,7 +49,7 @@ fn main() -> ! {
     // Get pointer to all device peripherals.
     let mut hal = hal::new();
 
-    let clocks = hal::ClockRequirements::default()
+    let _clocks = hal::ClockRequirements::default()
         .system_frequency(12.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
@@ -105,7 +85,7 @@ fn main() -> ! {
     // turn on!
     adc.ctrl.modify(|_, w| {w.adcen().set_bit()});
 
-    heprintln!("Auto calibrating..");
+    heprintln!("Auto calibrating..").unwrap();
     autocal(& adc);
 
     // channel 13 (1V ref), single ended A, high res

--- a/examples/ctimer.rs
+++ b/examples/ctimer.rs
@@ -11,6 +11,8 @@ use cortex_m_semihosting::heprintln;
 use lpc55_hal as hal;
 use hal::prelude::*;
 
+use hal::drivers::timer::Lap;
+
 #[macro_use(block)]
 extern crate nb;
 

--- a/examples/ctimer.rs
+++ b/examples/ctimer.rs
@@ -11,6 +11,9 @@ use cortex_m_semihosting::heprintln;
 use lpc55_hal as hal;
 use hal::prelude::*;
 
+#[macro_use(block)]
+extern crate nb;
+
 use hal::drivers::{
     Timer,
 };
@@ -23,30 +26,21 @@ fn main() -> ! {
     // Get pointer to all device peripherals.
     let mut hal = hal::new();
 
-    let clocks = hal::ClockRequirements::default()
+    let _clocks = hal::ClockRequirements::default()
         .system_frequency(12.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
 
     let ctimer = hal.ctimer.1.enabled(&mut hal.syscon);
+    let mut cdriver = Timer::new(ctimer);
 
-    let cdriver = Timer::new(ctimer);
-
-    let ctimer = cdriver.release();
-    let ctimer = ctimer.release();
-
-    ctimer.ctcr.write(|w| {
-        w.ctmode().timer()
-    });
-
-    // Timer increment ~1KHz
-    ctimer.pr.write(|w| unsafe {w.bits(12000-1)});
-    ctimer.tcr.write(|w| {w.cen().set_bit()});
-
-    let mut t = 0u32;
+    heprintln!("looping 1 Hz").unwrap();
+    let mut c = 0;
     loop {
-        t = ctimer.tc.read().bits();
-        dbg!(t);
-        hal::wait_at_least(1000);
+        cdriver.start(1.s());
+        dbg!(c * 1_000_000);
+        dbg!(cdriver.lap().0);
+        c += 1;
+        block!(cdriver.wait()).unwrap(); // blocks for 1 second
     }
 }

--- a/examples/ctimer.rs
+++ b/examples/ctimer.rs
@@ -1,0 +1,39 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_semihosting;  // 4004 bytes
+// extern crate panic_halt; // 672 bytes
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::dbg;
+use cortex_m_semihosting::heprintln;
+
+use lpc55_hal as hal;
+use hal::prelude::*;
+
+
+#[entry]
+fn main() -> ! {
+
+    heprintln!("Hello ADC").unwrap();
+
+    // Get pointer to all device peripherals.
+    let mut hal = hal::new();
+
+    let clocks = hal::ClockRequirements::default()
+        .system_frequency(12.mhz())
+        .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
+        .unwrap();
+
+    let ctimer = hal.CTIMER1;
+
+    let tst = ctimer.ccr.read().bits();
+
+    // let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
+    // let adc = hal::Adc::from(dp.ADC0).enabled(&mut syscon);
+
+    heprintln!("looping").unwrap();
+    loop {
+
+    }
+}

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -8,7 +8,7 @@ extern crate panic_semihosting;  // 4004 bytes
 extern crate nb;
 
 use cortex_m_rt::entry;
-use cortex_m_semihosting::dbg;
+// use cortex_m_semihosting::dbg;
 use cortex_m_semihosting::heprintln;
 
 use lpc55_hal as hal;
@@ -17,62 +17,17 @@ use hal::{
     drivers::{
         Pins,
         Timer,
+        TouchSensor,
     }
 };
 
-fn delay(count: u32){
-    for i in 0 .. (1_000 * count) {
 
-    }
-}
-
-// Reads normal sample (CMDL2 + trigger 2)
-fn read_sample(adc: & hal::raw::ADC0) -> u16{
-    adc.swtrig.write(|w| unsafe {w.bits(1<<2)});
-    while adc.fctrl[0].read().fcount().bits() == 0 {
-    }
-    let result = adc.resfifo[0].read().bits();
-    assert!( (result & 0x80000000) != 0 );
-    let sample = (result & 0xffff) as u16;
-    sample
-}
-
-fn autocal (adc: & hal::raw::ADC0) {
-    // Calibration + offset trimming
-    adc.ofstrim.write(|w| unsafe {
-        w.ofstrim_a().bits(10)
-        .ofstrim_b().bits(10)
-    });
-
-    // Request calibration
-    adc.ctrl.modify(|_,w| {w.cal_req().set_bit()});
-
-    // wait for auto-cal to be ready.
-    while (!adc.gcc[0].read().rdy().bits()) || (!adc.gcc[1].read().rdy().bits()) {
-    }
-
-    let gain_a = adc.gcc[0].read().gain_cal().bits();
-    let gain_b = adc.gcc[1].read().gain_cal().bits();
-
-    let gcr_a = (((gain_a as u32) << 16) / (0x1FFFFu32 - gain_a as u32 )) as u16;
-    let gcr_b = (((gain_b as u32) << 16) / (0x1FFFFu32 - gain_b as u32 )) as u16;
-
-    adc.gcr[0].write(|w| unsafe {w.gcalr().bits(gcr_a)});
-    adc.gcr[1].write(|w| unsafe {w.gcalr().bits(gcr_b)});
-
-    adc.gcr[0].write(|w| {w.rdy().set_bit()});
-    adc.gcr[1].write(|w| {w.rdy().set_bit()});
-
-    while !adc.stat.read().cal_rdy().bits() {
-    }
-}
 
 #[entry]
 fn main() -> ! {
 
-    heprintln!("Hello ADC").unwrap();
+    heprintln!("Hello Touch").unwrap();
 
-    let CThreshold = 12_000;
 
     // Get pointer to all device peripherals.
     let mut hal = hal::new();
@@ -84,159 +39,41 @@ fn main() -> ! {
 
     let mut gpio = hal.gpio.enabled(&mut hal.syscon);
 
-    let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
-
-    let ctimer = hal.ctimer.1.enabled(&mut hal.syscon);
-    let mut cdriver = Timer::new(ctimer);
 
     let mut iocon = hal.iocon.enabled(&mut hal.syscon);
     let pins = Pins::take().unwrap();
     let _but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);
-    let _but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);
+    let but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);
     let _but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);
 
-    let mut charge_pin = pins.pio1_16.into_gpio_pin(&mut iocon, &mut gpio).into_output_high();
-    charge_pin.set_low().unwrap();
+    let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
+    let touch_timer = Timer::new(hal.ctimer.1.enabled(&mut hal.syscon));
+    let charge_pin = pins.pio1_16.into_gpio_pin(&mut iocon, &mut gpio).into_output_low();
 
-    let adc = adc.release();
+    let mut touch_sensor = TouchSensor::new(adc, touch_timer, charge_pin, 12_000).unwrap();
 
-    adc.ctrl.write(|w| {
-        w.dozen().set_bit()
-        .cal_avgs().cal_avgs_7()
-    });
-
-    adc.cfg.write(|w| unsafe {
-        w.pwren().set_bit()
-        .pudly().bits(0x80)
-        .refsel().refsel_1()
-        .pwrsel().pwrsel_3()
-        .tprictrl().bits(0)
-        .tres().clear_bit() // Do not resume interrupted captures
-    });
-
-
-    // No pause for now, but could be interesting
-    adc.pause.write(|w| unsafe {w.bits(0)});
-
-    // Set 0 for watermark
-    adc.fctrl[0].write(|w| unsafe{w.fwmark().bits(0)});
-    adc.fctrl[1].write(|w| unsafe{w.fwmark().bits(0)});
-
-
-    // turn on!
-    adc.ctrl.modify(|_, w| {w.adcen().set_bit()});
-
-    heprintln!("Auto calibrating..").unwrap();
-    autocal(& adc);
-
-    //// CMDL1 used for threshold measurement.
-    adc.cmdl1.write(|w| unsafe {  w.adch().bits(3)
-                                .ctype().ctype_0()  
-                                .mode().mode_0()
-                                } );
-    adc.cmdh1.write(|w| unsafe { w.avgs().avgs_3()      // average 2^3 samples
-                                .cmpen().bits(0b11)        // compare repeatedly until true
-                                // .cmpen().bits(0b00)        // No compare function
-                                .loop_().bits(0)         // no loop
-                                .next().bits(0)         // no next command
-                            } );
-    ////
-    //// CMDL2 used for normal measurement
-    adc.cmdl2.write(|w| unsafe {  w.adch().bits(3)
-                                .ctype().ctype_0()  
-                                .mode().mode_0()
-                                } );
-    adc.cmdh2.write(|w| unsafe { w.avgs().avgs_3()
-                                .cmpen().bits(0b00)        // no compare
-                                .loop_().bits(0)
-                                .next().bits(0)
-                            } );
-    ////
-
-
-    // Configure compare operation to (result > CThreshold ? true : false)
-    adc.cv1.write(|w| unsafe {
-        w.cvl().bits(0)
-        .cvh().bits(CThreshold)
-    });
-
-    // Main trigger
-    adc.tctrl[0].write(|w| unsafe {
-        w.hten().set_bit()
-        .fifo_sel_a().fifo_sel_a_0()
-        .fifo_sel_b().fifo_sel_b_0()
-        .tcmd().bits(1)
-        .tpri().bits(3)
-    });
-
-    // Cancel/resync trigger to main trigger
-    adc.tctrl[1].write(|w| unsafe {
-        w.hten().set_bit()
-        .fifo_sel_a().fifo_sel_a_0()
-        .fifo_sel_b().fifo_sel_b_0()
-        .tcmd().bits(0)
-        .rsync().set_bit()
-        .tpri().bits(0) //highest priority
-    });
-
-    // Normal measurement trigger
-    adc.tctrl[2].write(|w| unsafe {
-        w.hten().set_bit()
-        .fifo_sel_a().fifo_sel_a_0()
-        .fifo_sel_b().fifo_sel_b_0()
-        .tcmd().bits(2)
-        .tpri().bits(2)
-    });
+    let mut cdriver = Timer::new(hal.ctimer.2.enabled(&mut hal.syscon));
 
 
     heprintln!("looping").unwrap();
-    let mut samples = [0u16; 32];
-    let mut timeout = 0;
-    heprintln!("adc status: {:02X}", adc.stat.read().bits());
+    // heprintln!("adc status: {:02X}", touch_sensor.stat.read().bits()).unwrap();
     loop {
 
-        // Discharge for 100ms
-        charge_pin.set_low().unwrap();
-
+        // Some delay before start of period.
         cdriver.start(1.ms());
         block!(cdriver.wait()).unwrap();
 
+        // Measure button 2
+        let t = touch_sensor.measure(&but2).unwrap();
 
-
+        // Delay again and get a normal measurement to see max charge value (Only for debugging / tuning) 
         cdriver.start(1.ms());
-
-
-        //get sample + start charge
-        adc.swtrig.write(|w| unsafe {w.bits(1)});
-        charge_pin.set_high().unwrap();
-        while adc.fctrl[0].read().fcount().bits() == 0 {
-            if cdriver.lap().0 > 900 {
-                heprintln!("timeout status: {:02X}, {:02X}", adc.stat.read().bits(), adc.cmdh1.read().bits());
-                adc.swtrig.write(|w| unsafe {w.bits(2)});
-                adc.ctrl.modify(|_,w| { w.rstfifo0().set_bit().rstfifo1().set_bit() });
-                block!(cdriver.wait()).unwrap();
-                timeout = 1;
-                break
-            }
-        }
-        if timeout == 1 {
-            timeout = 0;
-            continue;
-        }
-        let result = adc.resfifo[0].read().bits();
-        assert!( (result & 0x80000000) != 0 );
-        let sample = (result & 0xffff) as u16;
+        block!(cdriver.wait()).unwrap();
+        let max = touch_sensor.read(&but2).unwrap();
+        heprintln!("{} - {}", t.0, max).unwrap();
         //
 
-        let t = cdriver.lap();
-
-        block!(cdriver.wait()).unwrap();
-        let mut max = 1;
-        max = read_sample(&adc);
-
-        // dbg!(t.0);
-        // dbg!(sample);
-
-        heprintln!("{} - {}/{}  {:02X}", t.0, sample,max, adc.stat.read().bits()).unwrap();
+        // Discharge at end of period
+        touch_sensor.discharge().unwrap();
     }
 }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -1,0 +1,177 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_semihosting;  // 4004 bytes
+// extern crate panic_halt; // 672 bytes
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::dbg;
+use cortex_m_semihosting::heprintln;
+
+use lpc55_hal as hal;
+use hal::prelude::*;
+use hal::{
+    drivers::{
+        Pins,
+    }
+};
+
+fn delay(count: u32){
+    for i in 0 .. (1_000 * count) {
+
+    }
+}
+
+fn read_sample(adc: & hal::raw::ADC0) -> u16{
+    adc.swtrig.write(|w| unsafe {w.bits(1)});
+    while adc.fctrl[0].read().fcount().bits() == 0 {
+    }
+    let result = adc.resfifo[0].read().bits();
+    assert!( (result & 0x80000000) != 0 );
+    let sample = (result & 0xffff) as u16;
+    sample
+}
+
+fn autocal (adc: & hal::raw::ADC0) {
+    // Calibration + offset trimming
+    adc.ofstrim.write(|w| unsafe {
+        w.ofstrim_a().bits(10)
+        .ofstrim_b().bits(10)
+    });
+
+    // Request calibration
+    adc.ctrl.modify(|_,w| {w.cal_req().set_bit()});
+
+    // wait for auto-cal to be ready.
+    while (!adc.gcc[0].read().rdy().bits()) || (!adc.gcc[1].read().rdy().bits()) {
+    }
+
+    let gain_a = adc.gcc[0].read().gain_cal().bits();
+    let gain_b = adc.gcc[1].read().gain_cal().bits();
+
+    let gcr_a = (((gain_a as u32) << 16) / (0x1FFFFu32 - gain_a as u32 )) as u16;
+    let gcr_b = (((gain_b as u32) << 16) / (0x1FFFFu32 - gain_b as u32 )) as u16;
+
+    adc.gcr[0].write(|w| unsafe {w.gcalr().bits(gcr_a)});
+    adc.gcr[1].write(|w| unsafe {w.gcalr().bits(gcr_b)});
+
+    adc.gcr[0].write(|w| {w.rdy().set_bit()});
+    adc.gcr[1].write(|w| {w.rdy().set_bit()});
+
+    while !adc.stat.read().cal_rdy().bits() {
+    }
+}
+
+#[entry]
+fn main() -> ! {
+
+    heprintln!("Hello ADC").unwrap();
+
+    // Get pointer to all device peripherals.
+    let mut hal = hal::new();
+
+    let _clocks = hal::ClockRequirements::default()
+        .system_frequency(12.mhz())
+        .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
+        .unwrap();
+
+    let mut gpio = hal.gpio.enabled(&mut hal.syscon);
+
+    let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
+    // let adc = hal::Adc::from(dp.ADC0).enabled(&mut syscon);
+
+    let mut iocon = hal.iocon.enabled(&mut hal.syscon);
+    let pins = Pins::take().unwrap();
+    let _but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);
+    let _but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);
+    let _but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);
+
+    let mut charge_pin = pins.pio1_16.into_gpio_pin(&mut iocon, &mut gpio).into_output_high();
+    charge_pin.set_low().unwrap();
+
+    let adc = adc.release();
+
+    adc.ctrl.write(|w| {
+        w.dozen().set_bit()
+        .cal_avgs().cal_avgs_7()
+    });
+
+    adc.cfg.write(|w| unsafe {
+        w.pwren().set_bit()
+        .pudly().bits(0x80)
+        .refsel().refsel_1()
+        .pwrsel().pwrsel_1()
+        .tprictrl().bits(0)
+    });
+
+
+    // No pause for now, but could be interesting
+    adc.pause.write(|w| unsafe {w.bits(0)});
+
+    // Set 0 for watermark
+    adc.fctrl[0].write(|w| unsafe{w.fwmark().bits(0)});
+    adc.fctrl[1].write(|w| unsafe{w.fwmark().bits(0)});
+
+
+    // turn on!
+    adc.ctrl.modify(|_, w| {w.adcen().set_bit()});
+
+    heprintln!("Auto calibrating..").unwrap();
+    autocal(& adc);
+
+    // channel 12 (button 1), single ended A, high res
+    adc.cmdl1.write(|w| unsafe {  w.adch().bits(3)
+                                .ctype().ctype_0()  
+                                .mode().mode_0()
+                                } );
+
+    adc.cmdh1.write(|w| unsafe { w.avgs().avgs_5()      // average 2^5 samples
+                                .cmpen().bits(0)        // disable compare
+                                .loop_().bits(0)         // no loop
+                                .next().bits(0)         // no next command
+                            } );
+
+    adc.tctrl[0].write(|w| unsafe {
+        w.hten().set_bit()
+        .fifo_sel_a().fifo_sel_a_0()
+        .fifo_sel_b().fifo_sel_b_0()
+        .tcmd().bits(1)
+    });
+
+    heprintln!("ADC CTRL. {:02X}", adc.ctrl.read().bits()).unwrap();
+    heprintln!("ADC  CFG. {:02X}", adc.cfg.read().bits()).unwrap();
+    heprintln!("ADC stat: {:02X}", adc.stat.read().bits()).unwrap();
+
+    // SW trigger the trigger event 0
+    adc.swtrig.write(|w| unsafe {w.bits(1)});
+
+    dbg!("triggered");
+
+    let count0 = adc.fctrl[0].read().fcount().bits();
+
+    heprintln!("FIFO0 conversions {}", count0).unwrap();
+
+    let result = adc.resfifo[0].read().bits();
+    let valid = result & 0x80000000;
+    let sample = (result & 0xffff) as u16;
+   
+    if valid != 0 {
+        heprintln!("sample = {:02x}", sample).unwrap();
+    } else {
+        heprintln!("No result from ADC!").unwrap();
+    }
+
+
+    heprintln!("looping").unwrap();
+    let mut samples = [0u16; 32];
+    loop {
+        charge_pin.set_low().unwrap();
+        delay(5);
+        charge_pin.set_high().unwrap();
+        for i in 0..samples.len(){
+            samples[i] = read_sample(&adc);
+        }
+        dbg!(samples);
+        // heprintln!("samples = {}", sample).unwrap();
+    }
+}

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -8,7 +8,7 @@ extern crate panic_semihosting;  // 4004 bytes
 extern crate nb;
 
 use cortex_m_rt::entry;
-// use cortex_m_semihosting::dbg;
+use cortex_m_semihosting::dbg;
 use cortex_m_semihosting::heprintln;
 
 use lpc55_hal as hal;
@@ -17,11 +17,19 @@ use hal::{
     drivers::{
         Pins,
         Timer,
+        timer::Lap,
         TouchSensor,
     }
 };
-
-
+pub use hal::typestates::pin::state;
+pub use hal::typestates::pin::gpio::{
+    direction,
+};
+struct Buttons(
+    hal::drivers::pins::Pin<hal::drivers::pins::Pio1_9, state::Analog<direction::Input>>, 
+    hal::drivers::pins::Pin<hal::drivers::pins::Pio0_31, state::Analog<direction::Input>>, 
+    hal::drivers::pins::Pin<hal::drivers::pins::Pio0_15, state::Analog<direction::Input>>, 
+);
 
 #[entry]
 fn main() -> ! {
@@ -32,48 +40,133 @@ fn main() -> ! {
     // Get pointer to all device peripherals.
     let mut hal = hal::new();
 
-    let _clocks = hal::ClockRequirements::default()
-        .system_frequency(12.mhz())
+    let clocks = hal::ClockRequirements::default()
+        .system_frequency(96.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
+
+    let touch_token = clocks.support_touch_token().unwrap();
+
 
     let mut gpio = hal.gpio.enabled(&mut hal.syscon);
 
 
     let mut iocon = hal.iocon.enabled(&mut hal.syscon);
     let pins = Pins::take().unwrap();
-    let _but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);
+
+    let but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);
     let but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);
-    let _but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);
+    let but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);
+    let buttons = Buttons(but1,but2,but3);
 
     let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
     let touch_timer = Timer::new(hal.ctimer.1.enabled(&mut hal.syscon));
     let charge_pin = pins.pio1_16.into_gpio_pin(&mut iocon, &mut gpio).into_output_low();
 
-    let mut touch_sensor = TouchSensor::new(adc, touch_timer, charge_pin, 12_000).unwrap();
+    let mut touch_sensor = TouchSensor::new(adc, touch_timer, charge_pin, 9_000, 12_000, touch_token).unwrap();
 
     let mut cdriver = Timer::new(hal.ctimer.2.enabled(&mut hal.syscon));
 
-
     heprintln!("looping").unwrap();
     // heprintln!("adc status: {:02X}", touch_sensor.stat.read().bits()).unwrap();
+    let mut t0 =0; let mut t1 =0; let mut t2=0;
+    let mut max0 = 0; let mut max1 = 0;let mut max2 = 0;
     loop {
 
         // Some delay before start of period.
-        cdriver.start(1.ms());
-        block!(cdriver.wait()).unwrap();
+        // cdriver.start(1.ms());
+        // block!(cdriver.wait()).unwrap();
+
+        // // Measure button 1
+        // t0 = touch_sensor.measure(&buttons.0).unwrap().0;
+
+
+        // // Delay again and get a normal measurement to see max charge value (Only for debugging / tuning) 
+        // cdriver.start(1.ms());
+        // block!(cdriver.wait()).unwrap();
+        // max0 = touch_sensor.read(&buttons.0).unwrap();
+        // //
+
+        // // Discharge at end of period
+        // touch_sensor.discharge().unwrap();
+
+        /////////////
+
+        // Some delay before start of period.
+        let averages = 1;
+
+        let mut samples = [0u32; 128];
+        let mut times = [0u32; 128];
+
+        for i in 0..averages {
 
         // Measure button 2
-        let t = touch_sensor.measure(&but2).unwrap();
+        // let t1 = touch_sensor.measure(&buttons.2).unwrap();
+            touch_sensor.charge().unwrap();
+            samples[i] = touch_sensor.read(&buttons.2).unwrap() as u32;
+            // touch_sensor.discharge().unwrap();
+            // samples[i] += touch_sensor.read(&buttons.2).unwrap() as u32;
 
-        // Delay again and get a normal measurement to see max charge value (Only for debugging / tuning) 
-        cdriver.start(1.ms());
-        block!(cdriver.wait()).unwrap();
-        let max = touch_sensor.read(&but2).unwrap();
-        heprintln!("{} - {}", t.0, max).unwrap();
-        //
+            cdriver.start(2.ms());
+            block!(cdriver.wait()).unwrap();
 
-        // Discharge at end of period
-        touch_sensor.discharge().unwrap();
+        }
+            touch_sensor.discharge().unwrap();
+            cdriver.start(2.ms());
+            block!(cdriver.wait()).unwrap();
+            let low = touch_sensor.read(&buttons.1).unwrap();
+
+        // max1 = touch_sensor.read(&buttons.1).unwrap();
+        // touch_sensor.discharge().unwrap();
+        // cdriver.start(2.ms());
+        // block!(cdriver.wait()).unwrap();
+
+        // Measure button 2
+        // t1 = touch_sensor.measure(&buttons.1).unwrap().0;
+
+        // // Delay again and get a normal measurement to see max charge value (Only for debugging / tuning) 
+        // cdriver.start(1.ms());
+        // block!(cdriver.wait()).unwrap();
+        // max1 = touch_sensor.read(&buttons.1).unwrap();
+        // //
+
+        // // Discharge at end of period
+        // touch_sensor.discharge().unwrap();
+
+        // /////////////
+
+        // // Some delay before start of period.
+        // cdriver.start(1.ms());
+        // block!(cdriver.wait()).unwrap();
+
+        // // Measure button 3
+        // t2 = touch_sensor.measure(&buttons.2).unwrap().0;
+
+        // // Delay again and get a normal measurement to see max charge value (Only for debugging / tuning) 
+        // cdriver.start(1.ms());
+        // block!(cdriver.wait()).unwrap();
+        // max2 = touch_sensor.read(&buttons.2).unwrap();
+        // //
+
+        // // Discharge at end of period
+        // touch_sensor.discharge().unwrap();
+
+
+
+        // heprintln!("0: {}-{}, 1: {}-{}, 2: {}-{}", t0, max0, t1, max1, t2, max2).unwrap();
+        let mut sum = 0u32;
+        for i in 0..averages {
+            sum += samples[i] as u32;
+        }
+        // for i in 0..2 {
+        //     heprintln!("{:06}  {:06}", samples[i], times[i]);
+        // }
+
+        heprintln!("ave: {:02}, {:02} {:02} {:02} {:02}", sum / (averages as u32), samples[0], samples[1], samples[2], samples[3], ).unwrap();
+        // heprintln!("ave: {:02}, low: {:02}", sum / (averages as u32), low, ).unwrap();
+
+
+        // dbg!(samples);
+        // heprintln!("{}-{}",  t1.0, max1, ).unwrap();
     }
 }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -31,6 +31,15 @@ struct Buttons(
     hal::drivers::pins::Pin<hal::drivers::pins::Pio0_15, state::Analog<direction::Input>>, 
 );
 
+fn get_average(arr: &[u16]) -> u32{
+    let mut sum = 0u32;
+    for i in 0 .. arr.len() {
+        sum += arr[i] as u32;
+    }
+    
+    sum / (arr.len() as u32)
+}
+
 #[entry]
 fn main() -> ! {
 
@@ -54,27 +63,160 @@ fn main() -> ! {
     let mut iocon = hal.iocon.enabled(&mut hal.syscon);
     let pins = Pins::take().unwrap();
 
-    let but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);
-    let but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);
-    let but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);
+    let but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);        // channel 12
+    let but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);       // channel 3
+    let but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);       // channel 2
     let buttons = Buttons(but1,but2,but3);
 
     let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
-    let touch_timer = Timer::new(hal.ctimer.1.enabled(&mut hal.syscon));
-    let charge_pin = pins.pio1_16.into_gpio_pin(&mut iocon, &mut gpio).into_output_low();
-
-    let mut touch_sensor = TouchSensor::new(adc, touch_timer, charge_pin, 9_000, 12_000, touch_token).unwrap();
 
     let mut cdriver = Timer::new(hal.ctimer.2.enabled(&mut hal.syscon));
 
+    let adc = adc.release();
+
+    let charge_pin = pins.pio1_16.into_ctimer1_mat3(&mut iocon);
+
+    let touch_timer = Timer::new(hal.ctimer.1.enabled(&mut hal.syscon));
+    let touch_timer = touch_timer.release().release();
+
+    // First match (0) triggers MAT to go LOW, discharge.
+    // Last match (3) triggers MAT to go HIGH, start charging, interrupt ADC trigger.
+    touch_timer.mcr.write(|w| {
+        w
+        // .mr0i().set_bit()          // no interrupt
+        // .mr0r().clear_bit()           // no reset
+        // .mr0s().clear_bit()         // do not stop.
+
+        .mr3i().set_bit()          // enable interrupt
+        .mr3r().set_bit()           // reset timer
+        .mr3s().clear_bit()         // do not stop.
+    } );
+
+    touch_timer.emr.write(|w| {
+        w
+        // .emc0().clear()             // match 0 discharge
+        .emc3().toggle()               // match 3 charge
+    });
+
+
+    // MR3 starts charge or discharge.  1000 us should be ample time to either charge or discharge;
+    touch_timer.mr[3].write(|w| unsafe { w.bits(1000) });
+
+    // Clear mr3 interrupt
+    touch_timer.ir.write(|w| { w.mr3int().set_bit() });     // setting bit clears it
+
+    // CTIMER1 MAT3 trigger == 6 (Table 736.)
+    adc.tctrl[6].write(|w| unsafe {
+        w.hten().set_bit()
+        .fifo_sel_a().fifo_sel_a_0()
+        .fifo_sel_b().fifo_sel_b_0()
+        .tcmd().bits(3)                 // Target cmd 3
+        .tpri().bits(2)
+    });
+
+
+    adc.cmdl3.write(|w| unsafe {  w.adch().bits(12)
+                                .ctype().ctype_0()  
+                                .mode().mode_0()
+                                } );
+    adc.cmdh3.write(|w| unsafe { w.avgs().avgs_7()
+                                .cmpen().bits(0b00)        // no compare
+                                .loop_().bits(0)
+                                .next().bits(4)
+                                .wait_trig().set_bit()
+                            } );
+
+
+    adc.cmdl4.write(|w| unsafe {  w.adch().bits(3)
+                                .ctype().ctype_0()  
+                                .mode().mode_0()
+                                } );
+    adc.cmdh4.write(|w| unsafe { w.avgs().avgs_7()
+                                .cmpen().bits(0b00)        // no compare
+                                .loop_().bits(0)
+                                .next().bits(5)
+                                .wait_trig().set_bit()
+                            } );
+
+
+    adc.cmdl5.write(|w| unsafe {  w.adch().bits(2)
+                                .ctype().ctype_0()  
+                                .mode().mode_0()
+                                } );
+    adc.cmdh5.write(|w| unsafe { w.avgs().avgs_7()
+                                .loop_().bits(0)
+                                .next().bits(3)
+                                .wait_trig().set_bit()
+                            } );
+
+    // Start timer
+    touch_timer.tcr.write(|w| {
+        w.crst().clear_bit()
+        .cen().set_bit()
+    });
+
+
     heprintln!("looping").unwrap();
-    // heprintln!("adc status: {:02X}", touch_sensor.stat.read().bits()).unwrap();
-    let mut t0 =0; let mut t1 =0; let mut t2=0;
-    let mut max0 = 0; let mut max1 = 0;let mut max2 = 0;
+    let mut hist1 = [0u16; 32];
+    let mut hist2 = [0u16; 32];
+    let mut hist3 = [0u16; 32];
+    let mut iter1 = 0;
+    let mut iter2 = 0;
+    let mut iter3 = 0;
+
+    let mut hist_source = [0u8; 32];
+
+    cdriver.start(300.ms());
+    let mut total = 0u32;
+
     loop {
 
+        let count = adc.fctrl[0].read().fcount().bits();
+        if count > 0 {
+
+
+
+            let result = adc.resfifo[0].read().bits();
+            assert!((result & 0x80000000) != 0);
+            let sample = (result & 0xffff) as u16;
+
+            let src = ((result & (0xf << 24)) >> 24) as u8;
+
+            match src {
+                3 => {
+                    hist1[iter1] = sample;
+                    iter1 = (iter1 + 1) % 32;
+                },
+                4 => {
+                    hist2[iter2] = sample;
+                    iter2 = (iter2 + 1) % 32;
+                },
+                5 => {
+                    hist3[iter3] = sample;
+                    iter3 = (iter3 + 1) % 32;
+                },
+                _ => {
+                    assert!(false);
+                }
+            };
+
+            total += 1;
+
+            // heprintln!("{} ({})", sample, count).unwrap();
+
+        }
+
+        if cdriver.wait().is_ok() {
+            cdriver.start(1000.ms());
+            heprintln!("av: {:05} {:05} {:05} ({}, {})", get_average(&hist1), get_average(&hist2), get_average(&hist3), count, total).unwrap();
+            // dbg!(hist_source);
+            total = 0;
+
+        }
+
+        // heprintln!("timer: {:02x}, {:02x}, {}", touch_timer.tcr.read().bits(), touch_timer.emr.read().bits(), touch_timer.tc.read().bits()).unwrap();
+
         // Some delay before start of period.
-        // cdriver.start(1.ms());
         // block!(cdriver.wait()).unwrap();
 
         // // Measure button 1
@@ -93,28 +235,28 @@ fn main() -> ! {
         /////////////
 
         // Some delay before start of period.
-        let averages = 1;
+        // let averages = 1;
 
-        let mut samples = [0u32; 128];
-        let mut times = [0u32; 128];
+        // let mut samples = [0u32; 128];
+        // let mut times = [0u32; 128];
 
-        for i in 0..averages {
+        // for i in 0..averages {
 
-        // Measure button 2
-        // let t1 = touch_sensor.measure(&buttons.2).unwrap();
-            touch_sensor.charge().unwrap();
-            samples[i] = touch_sensor.read(&buttons.2).unwrap() as u32;
-            // touch_sensor.discharge().unwrap();
-            // samples[i] += touch_sensor.read(&buttons.2).unwrap() as u32;
+        // // Measure button 2
+        // // let t1 = touch_sensor.measure(&buttons.2).unwrap();
+        //     touch_sensor.charge().unwrap();
+        //     samples[i] = touch_sensor.read(&buttons.2).unwrap() as u32;
+        //     // samples[i] += touch_sensor.read(&buttons.2).unwrap() as u32;
 
-            cdriver.start(2.ms());
-            block!(cdriver.wait()).unwrap();
+        //     touch_sensor.discharge().unwrap();
+        //     cdriver.start(2.ms());
+        //     block!(cdriver.wait()).unwrap();
 
-        }
-            touch_sensor.discharge().unwrap();
-            cdriver.start(2.ms());
-            block!(cdriver.wait()).unwrap();
-            let low = touch_sensor.read(&buttons.1).unwrap();
+        // }
+        //     touch_sensor.discharge().unwrap();
+        //     cdriver.start(2.ms());
+        //     block!(cdriver.wait()).unwrap();
+        //     let low = touch_sensor.read(&buttons.1).unwrap();
 
         // max1 = touch_sensor.read(&buttons.1).unwrap();
         // touch_sensor.discharge().unwrap();
@@ -154,15 +296,15 @@ fn main() -> ! {
 
 
         // heprintln!("0: {}-{}, 1: {}-{}, 2: {}-{}", t0, max0, t1, max1, t2, max2).unwrap();
-        let mut sum = 0u32;
-        for i in 0..averages {
-            sum += samples[i] as u32;
-        }
+        // let mut sum = 0u32;
+        // for i in 0..averages {
+        //     sum += samples[i] as u32;
+        // }
         // for i in 0..2 {
         //     heprintln!("{:06}  {:06}", samples[i], times[i]);
         // }
 
-        heprintln!("ave: {:02}, {:02} {:02} {:02} {:02}", sum / (averages as u32), samples[0], samples[1], samples[2], samples[3], ).unwrap();
+        // heprintln!("ave: {:02}, {:02} {:02} {:02} {:02}", sum / (averages as u32), samples[0], samples[1], samples[2], samples[3], ).unwrap();
         // heprintln!("ave: {:02}, low: {:02}", sum / (averages as u32), low, ).unwrap();
 
 

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -18,70 +18,11 @@ use hal::{
         Pins,
         Timer,
         TouchSensor,
+        touch::ButtonPins,
+        touch::ButtonState,
     }
 };
 pub use hal::typestates::pin::state;
-pub use hal::typestates::pin::gpio::{
-    direction,
-};
-
-#[derive(PartialEq)]
-enum ButtonState{
-    Pressed,
-    NotPressed
-}
-
-struct Buttons{
-    top: ButtonState,
-    bot: ButtonState,
-    mid: ButtonState,
-}
-
-fn get_button_state(results: &[u32]) -> Buttons{
-    let mut buts = Buttons{top: ButtonState::NotPressed, bot: ButtonState::NotPressed, mid: ButtonState::NotPressed};
-
-    let mut counts = [0u32; 3];
-    let mut sums = [0u32; 3];
-
-    // calculate running average for three buttons.
-    // readings for each are mixed in the array.
-    for i in 0 .. results.len() {
-        let res = results[i];
-        let sample = (res & 0xffff);
-        let src = ((res & (0xf << 24)) >> 24) as u8;
-
-        match src {
-            3 => {
-                counts[0] += 1;
-                sums[0] += sample;
-            }
-            4 => {
-                counts[1] += 1;
-                sums[1] += sample;
-            }
-            5 => {
-                counts[2] += 1;
-                sums[2] += sample;
-            }
-
-            _ => {
-                assert!(false);
-            }
-        }
-    }
-
-    if sums[0]/counts[0] < 10_000 {
-        buts.top = ButtonState::Pressed;
-    }
-    if sums[1]/counts[1] < 10_000 {
-        buts.bot= ButtonState::Pressed;
-    }
-    if sums[2]/counts[2] < 10_000 {
-        buts.mid = ButtonState::Pressed;
-    }
-
-    buts
-}
 
 
 #[entry]
@@ -89,133 +30,47 @@ fn main() -> ! {
 
     heprintln!("Hello Touch").unwrap();
 
-
-    // Get pointer to all device peripherals.
     let mut hal = hal::new();
 
-    let clocks = hal::ClockRequirements::default()
+    let _clocks = hal::ClockRequirements::default()
         .system_frequency(96.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
 
-    let _touch_token = clocks.support_touch_token().unwrap();
 
 
     let mut gpio = hal.gpio.enabled(&mut hal.syscon);
 
 
-
     let mut iocon = hal.iocon.enabled(&mut hal.syscon);
     let pins = Pins::take().unwrap();
 
-    let _but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);        // channel 12
-    let _but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);       // channel 3
-    let _but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);       // channel 2
+    let but1 = pins.pio1_9.into_analog_input(&mut iocon, &mut gpio);        // channel 12
+    let but2 = pins.pio0_31.into_analog_input(&mut iocon, &mut gpio);       // channel 3
+    let but3 = pins.pio0_15.into_analog_input(&mut iocon, &mut gpio);       // channel 2
+
+    let button_pins = ButtonPins(but1,but2,but3);
 
     let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
+
+    let touch_timer = hal.ctimer.1.enabled(&mut hal.syscon);
+    let charge_pin = pins.pio1_16.into_ctimer1_mat3(&mut iocon);
+
     let mut dma = hal::Dma::from(hal.DMA0).enabled(&mut hal.syscon);
 
-    let mut cdriver = Timer::new(hal.ctimer.2.enabled(&mut hal.syscon));
+    let touch_sensor = TouchSensor::new(10_000, adc, touch_timer, charge_pin, button_pins);
+    let touch_sensor = touch_sensor.enabled(&mut dma);
 
-    let mut adc = adc.release();
+    let mut delay_timer = Timer::new(hal.ctimer.2.enabled(&mut hal.syscon));
 
-    let _charge_pin = pins.pio1_16.into_ctimer1_mat3(&mut iocon);
-
-    let touch_timer = Timer::new(hal.ctimer.1.enabled(&mut hal.syscon));
-    let touch_timer = touch_timer.release().release();
-
-    // First match (0) triggers MAT to go LOW, discharge.
-    // Last match (3) triggers MAT to go HIGH, start charging, interrupt ADC trigger.
-    touch_timer.mcr.write(|w| {
-        w
-        // .mr0i().set_bit()          // no interrupt
-        // .mr0r().clear_bit()           // no reset
-        // .mr0s().clear_bit()         // do not stop.
-
-        .mr3i().set_bit()          // enable interrupt
-        .mr3r().set_bit()           // reset timer
-        .mr3s().clear_bit()         // do not stop.
-    } );
-
-    touch_timer.emr.write(|w| {
-        w
-        // .emc0().clear()             // match 0 discharge
-        .emc3().toggle()               // match 3 charge
-    });
-
-
-    // MR3 starts charge or discharge.  1000 us should be ample time to either charge or discharge;
-    touch_timer.mr[3].write(|w| unsafe { w.bits(800) });
-
-    // Clear mr3 interrupt
-    touch_timer.ir.write(|w| { w.mr3int().set_bit() });     // setting bit clears it
-
-    // CTIMER1 MAT3 trigger == 6 (Table 736.)
-    adc.tctrl[6].write(|w| unsafe {
-        w.hten().set_bit()
-        .fifo_sel_a().fifo_sel_a_0()
-        .fifo_sel_b().fifo_sel_b_0()
-        .tcmd().bits(3)                 // Target cmd 3
-        .tpri().bits(2)
-    });
-
-
-    adc.cmdl3.write(|w| unsafe {  w.adch().bits(12)
-                                .ctype().ctype_0()  
-                                .mode().mode_0()
-                                } );
-    adc.cmdh3.write(|w| unsafe { w.avgs().avgs_7()
-                                .cmpen().bits(0b00)        // no compare
-                                .loop_().bits(0)
-                                .next().bits(4)
-                                .wait_trig().set_bit()
-                            } );
-
-
-    adc.cmdl4.write(|w| unsafe {  w.adch().bits(3)
-                                .ctype().ctype_0()  
-                                .mode().mode_0()
-                                } );
-    adc.cmdh4.write(|w| unsafe { w.avgs().avgs_7()
-                                .cmpen().bits(0b00)        // no compare
-                                .loop_().bits(0)
-                                .next().bits(5)
-                                .wait_trig().set_bit()
-                            } );
-
-
-    adc.cmdl5.write(|w| unsafe {  w.adch().bits(2)
-                                .ctype().ctype_0()  
-                                .mode().mode_0()
-                                } );
-    adc.cmdh5.write(|w| unsafe { w.avgs().avgs_7()
-                                .loop_().bits(0)
-                                .next().bits(3)
-                                .wait_trig().set_bit()
-                            } );
-
-    let mut samples = [0u32; 112];
-
-    dma.configure_adc(&mut adc, &mut samples);
-
-    // Start timer
-    touch_timer.tcr.write(|w| {
-        w.crst().clear_bit()
-        .cen().set_bit()
-    });
-
-    cdriver.start(200.ms());
-    block!(cdriver.wait()).unwrap();
-
-    for i in 0 .. samples.len() {
-        assert!( samples[i] != 0 );
-    }
+    delay_timer.start(200.ms());
+    block!(delay_timer.wait()).unwrap();
 
     heprintln!("looping").unwrap();
 
     loop {
 
-        let buts = get_button_state(&samples);
+        let buts = touch_sensor.get_button_state();
 
         if buts.top == ButtonState::Pressed {
             heprintln!("top").unwrap();

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -20,10 +20,16 @@ use hal::{
         timer::Lap,
         TouchSensor,
         touch::ButtonPins,
-        touch::ButtonState,
+        touch::profile_touch_sensing,
+    },
+    traits::{
+        buttons,
+        buttons::ButtonPress,
+        buttons::ButtonEdge,
     }
 };
 pub use hal::typestates::pin::state;
+
 
 
 #[entry]
@@ -55,67 +61,51 @@ fn main() -> ! {
     let adc = hal::Adc::from(hal.ADC0).enabled(&mut hal.pmc, &mut hal.syscon);
 
     let touch_timer = hal.ctimer.1.enabled(&mut hal.syscon);
+    let touch_sync_timer = hal.ctimer.2.enabled(&mut hal.syscon);
     let charge_pin = pins.pio1_16.into_ctimer1_mat3(&mut iocon);
 
     let mut dma = hal::Dma::from(hal.DMA0).enabled(&mut hal.syscon);
 
 
-    let mut delay_timer = Timer::new(hal.ctimer.2.enabled(&mut hal.syscon));
+    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon));
+
+    let touch_sensor = TouchSensor::new(11_900, 5, adc, touch_timer, touch_sync_timer, charge_pin, button_pins);
+    let mut touch_sensor = touch_sensor.enabled(&mut dma);
+
+    // Used to get tunning information for capacitive touch
+    if 1 == 0 {
+        let mut counts = [0u32; 3];
+        let mut times = [0u32; 128];
+        let mut results = [0u32; 128];
+        profile_touch_sensing(&mut touch_sensor, &mut delay_timer, &mut results, &mut times );
+        for i in 0 .. 128 {
+            let src = (results[i] & (0xf << 24)) >> 24;
+            let sample_num = (times[i] - 3513)/1598;
+            let button_sample_num = (times[i] - 3513)/(1598 * 3);
+
+            heprintln!("{}\t{}\t{}\t{}\t{}\t{}",times[i], i, sample_num,src, counts[(src-3) as usize], button_sample_num).unwrap();
+
+            counts[(src - 3) as usize] += 1;
+        }
+    }
+
     delay_timer.start(300.ms());
-
-    let touch_sensor = TouchSensor::new(10_000, adc, touch_timer, charge_pin, button_pins);
-
-    let mut times = [0u32; 125];
-
-    let touch_sensor = touch_sensor.enabled(&mut dma);
-    let start = delay_timer.lap().0;
-    let results = touch_sensor.get_results();
-
-    // block!(delay_timer.wait()).unwrap();
-
-    while true {
-        let mut has_zero = false;
-        for i in 0 .. 125 {
-            if results[i] != 0 {
-                if times[i] == 0 {
-                    times[i] = delay_timer.lap().0 -start;
-                }
-            }
-            else {
-                has_zero = true;
-            }
-        }
-        if !has_zero {
-            break;
-        }
-    }
-
-    for i in 0 .. 125 {
-        heprintln!("{}: {}us", i, times[i]).unwrap();
-    }
+    block!(delay_timer.wait()).unwrap();
 
     loop {
 
-        let buts = touch_sensor.get_button_state();
+        assert!( touch_sensor.count(3) >= 40 );
+        assert!( touch_sensor.count(4) >= 40 );
+        assert!( touch_sensor.count(5) >= 40 );
 
-        // assert!( touch_sensor.count(3) >= 40 );
-        // assert!( touch_sensor.count(4) >= 40 );
-        // assert!( touch_sensor.count(5) >= 40 );
-
-        //     heprintln!("{:02} {:02} {:02}",
-        //     touch_sensor.count(3),
-        //     touch_sensor.count(4),
-        //     touch_sensor.count(5),
-        // ).unwrap();
-
-        if buts.top == ButtonState::Pressed {
-            heprintln!("top").unwrap();
+        let p = touch_sensor.wait_for_any_press();
+        if  p.is_ok() {
+            heprintln!("press {:?}", p.unwrap()).unwrap();
         }
-        if buts.bot == ButtonState::Pressed {
-            heprintln!("bot").unwrap();
-        }
-        if buts.mid == ButtonState::Pressed {
-            heprintln!("mid").unwrap();
+
+        let p = touch_sensor.wait_for_any_release();
+        if  p.is_ok() {
+            heprintln!("release {:?}", p.unwrap()).unwrap();
         }
 
     }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -39,12 +39,12 @@ fn main() -> ! {
 
     let mut hal = hal::new();
 
-    let _clocks = hal::ClockRequirements::default()
+    let clocks = hal::ClockRequirements::default()
         .system_frequency(96.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
 
-
+    let touch_token = clocks.support_touch_token().unwrap();
 
     let mut gpio = hal.gpio.enabled(&mut hal.syscon);
 
@@ -70,7 +70,7 @@ fn main() -> ! {
     let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon));
 
     let touch_sensor = TouchSensor::new(11_900, 5, adc, touch_timer, touch_sync_timer, charge_pin, button_pins);
-    let mut touch_sensor = touch_sensor.enabled(&mut dma);
+    let mut touch_sensor = touch_sensor.enabled(&mut dma, touch_token);
 
     // Used to get tunning information for capacitive touch
     if 1 == 0 {

--- a/scripts/extract-flexcomm-data.py
+++ b/scripts/extract-flexcomm-data.py
@@ -141,7 +141,9 @@ for PIN, alt, FUNCTION in data:
             else:
                 assert KINDS[0] == "SCK", KINDS
                 PERIPHERALS = ["USART"]
-                KINDS = ["CLK"]
+
+                PERIPHERALS = ["USART", "SPI"]
+                KINDS = ["SCLK", "SCK"]
         else:
             PERIPHERALS = ["USART", "I2C", "SPI"]
             if l == 4:
@@ -157,7 +159,7 @@ for PIN, alt, FUNCTION in data:
             KIND = "SCLK"
         if KIND.startswith("SSEL"):
             chip = KIND[-1]
-            KIND = KIND[:-1]
+            KIND = "CS"
         else:
             chip = None
 
@@ -183,11 +185,11 @@ for PIN, alt, FUNCTION in data:
 for PeripheralKindPin, Peripherali, FUNCTION, chip in sorted(set(implementations)):
     if chip is None:
         print(
-            f"impl<PIO: PinId> {PeripheralKindPin}<PIO, {Peripherali}> for Pin<PIO, Special<{FUNCTION}>> {{}}"
+            f"impl<PIO: PinId> fc::{PeripheralKindPin}<PIO, flexcomm::{Peripherali}> for Pin<PIO, Special<function::{FUNCTION}>> {{}}"
         )
     else:
         print(
-            f"impl<PIO: PinId> {PeripheralKindPin}<PIO, {Peripherali}> for Pin<PIO, Special<{FUNCTION}>> {{"
+            f"impl<PIO: PinId> fc::{PeripheralKindPin}<PIO, flexcomm::{Peripherali}> for Pin<PIO, Special<function::{FUNCTION}>> {{"
         )
         print(f"    const CS: ChipSelect = ChipSelect::Chip{chip};")
         print(f"}}")

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -37,3 +37,6 @@ pub mod rng;
 
 pub mod usbd;
 pub use usbd::UsbBus;
+
+pub mod timer;
+pub use timer::Timer;

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -40,3 +40,6 @@ pub use usbd::UsbBus;
 
 pub mod timer;
 pub use timer::Timer;
+
+pub mod touch;
+pub use touch::TouchSensor;

--- a/src/drivers/clocks.rs
+++ b/src/drivers/clocks.rs
@@ -5,7 +5,6 @@
 ///!
 ///! It is currently used to prepare for using the USBFSD and
 ///! Flexcomm peripherals.
-use cortex_m_semihosting::heprintln;
 use core::cmp::min;
 
 use crate::typestates::{
@@ -219,14 +218,8 @@ impl ClockRequirements {
                 (MainClock::Fro96Mhz, 96 / freq.0)
             },
             _ => {
-                syscon.raw.pll0clksel.write(|w| {w.sel().enum_0x0()});  // FRO12 clkin sel
-                let mut pll = Self::get_pll(freq.0);
-                pll.seli = 53;
-                pll.selp = 31;
-                pll.n = 8;
-                pll.p = 1;
-                pll.m = 200;
-                heprintln!("pll {:?}, freq {}", pll, freq.0).ok();
+                let pll = Self::get_pll(freq.0);
+                // heprintln!("pll {:?}, freq {}", pll, freq.0).ok();
 
                 pmc.raw.pdruncfg0.modify(|_, w| w
                     .pden_pll0().poweredoff()

--- a/src/drivers/pins.rs
+++ b/src/drivers/pins.rs
@@ -395,6 +395,14 @@ macro_rules! special_pins {
     }
 }
 
+special_pins! {
+    (Pio1_16, pio1_16): {
+        (3, CT1MAT3): [
+            (into_ctimer1_mat3, Ctimer1, Ctimer1Mat3),
+        ]
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // all that follows is generated with `scripts/extract-flexcomm-data.py`
 // NB: Pio0_13 and Pio0_14 have a repetition of methods, manually commented out

--- a/src/drivers/pins.rs
+++ b/src/drivers/pins.rs
@@ -175,6 +175,8 @@ macro_rules! pins {
                         },
                     }
                 }
+
+
             }
 
             impl $pin {
@@ -207,6 +209,56 @@ macro_rules! pins {
                 const MASK: u32 = 0x1 << $number;
                 const OFFSET: usize = (0x20 << $port) + (0x1 << $number);
                 const TYPE: PinType = $type;
+            }
+        )*
+    }
+}
+
+macro_rules! analog_pins {
+    ($(
+        $field:ident,
+        $pin:ident,
+        $port:expr,
+        $number:expr,
+        $type:expr,
+        $default_state_ty:ty,
+        $default_state_val:expr;
+    )*) => {
+        /// Transition pin to Analog input
+        $(
+            impl Pin<$pin, state::Unused>  {
+                pub fn into_analog_input(
+                    self,
+                    iocon: &mut Iocon<init_state::Enabled>,
+                    _: &mut Gpio<init_state::Enabled>,
+                ) -> Pin<$pin, state::Gpio<direction::Input>> {
+
+                    // TODO: need to set FUNC to 0 at minimum
+                    iocon.raw.$field.modify(|_, w| w
+                        .func().alt0() // FUNC $i, pin configured as $FUNCTION
+                        .mode().inactive() // MODE_INACT, no additional pin function
+                        .slew().standard() // SLEW_STANDARD, standard mode, slew rate control is enabled
+                        .invert().disabled() // INV_DI, input function is not inverted
+                        .digimode().analog() // DIGITAL_EN, enable digital fucntion
+                        .od().normal() // OPENDRAIN_DI, open drain is disabled
+                        .asw().set_bit() // ASW, analog input enabled
+                    );
+                    let pin = Pin {
+                        id: self.id,
+                        state: state::Gpio {
+                            // b: RegClusterProxy::new(),
+                            // w: RegClusterProxy::new(),
+                            dirset: RegClusterProxy::new(),
+                            dirclr: RegClusterProxy::new(),
+                            pin: RegClusterProxy::new(),
+                            set: RegClusterProxy::new(),
+                            clr: RegClusterProxy::new(),
+
+                            _direction: direction::Unknown,
+                        },
+                    };
+                    return pin.into_input();
+                }
             }
         )*
     }
@@ -282,6 +334,26 @@ pins!(
     pio1_31, Pio1_31, 1, 31, PinType::D, state::Unused, state::Unused;
 );
 
+analog_pins!(
+    pio0_0 , Pio0_0 , 0,  0, PinType::A, state::Unused, state::Unused;
+    pio0_9 , Pio0_9 , 0,  9, PinType::A, state::Unused, state::Unused;
+    pio0_10, Pio0_10, 0, 10, PinType::A, state::Unused, state::Unused;
+    pio0_11, Pio0_11, 0, 11, PinType::A, state::Special<function::SWCLK>,
+        state::Special{ _function: function::SWCLK {} };
+    pio0_12, Pio0_12, 0, 12, PinType::A, state::Special<function::SWDIO>,
+        state::Special{ _function: function::SWDIO {} };
+    pio0_15, Pio0_15, 0, 15, PinType::A, state::Unused, state::Unused;
+    pio0_16, Pio0_16, 0, 16, PinType::A, state::Unused, state::Unused;
+    pio0_18, Pio0_18, 0, 18, PinType::A, state::Unused, state::Unused;
+    pio0_23, Pio0_23, 0, 23, PinType::A, state::Unused, state::Unused;
+    pio0_31, Pio0_31, 0, 31, PinType::A, state::Unused, state::Unused;
+
+    pio1_0 , Pio1_0 , 1,  0, PinType::A, state::Unused, state::Unused;
+    pio1_8 , Pio1_8 , 1,  8, PinType::A, state::Unused, state::Unused;
+    pio1_9 , Pio1_9 , 1,  9, PinType::A, state::Unused, state::Unused;
+    pio1_14, Pio1_14, 1, 14, PinType::A, state::Unused, state::Unused;
+    pio1_19, Pio1_19, 1, 19, PinType::A, state::Unused, state::Unused;
+);
 
 macro_rules! special_pins {
     ($(

--- a/src/drivers/pins.rs
+++ b/src/drivers/pins.rs
@@ -397,8 +397,8 @@ macro_rules! special_pins {
 
 special_pins! {
     (Pio1_16, pio1_16): {
-        (3, CT1MAT3): [
-            (into_ctimer1_mat3, Ctimer1, Ctimer1Mat3),
+        (3, CTIMER_MAT): [
+            (into_ctimer1_mat3, Ctimer1, CtimerMatPin),
         ]
     }
 }

--- a/src/drivers/pins.rs
+++ b/src/drivers/pins.rs
@@ -410,11 +410,11 @@ special_pins! {
 ///////////////////////////////////////////////////////////////////////////////
 
 // TODO: remove the $Marker argument
-
-special_pins! {
+special_pins!{
     (Pio0_0, pio0_0): {
         (2, FC3_SCK): [
             (into_usart3_sclk_pin, Usart3, UsartSclkPin),
+            (into_spi3_sck_pin, Spi3, SpiSckPin),
         ]
     }
     (Pio0_1, pio0_1): {
@@ -443,6 +443,7 @@ special_pins! {
     (Pio0_4, pio0_4): {
         (2, FC4_SCK): [
             (into_usart4_sclk_pin, Usart4, UsartSclkPin),
+            (into_spi4_sck_pin, Spi4, SpiSckPin),
         ]
     }
     (Pio0_5, pio0_5): {
@@ -463,6 +464,7 @@ special_pins! {
     (Pio0_6, pio0_6): {
         (1, FC3_SCK): [
             (into_usart3_sclk_pin, Usart3, UsartSclkPin),
+            (into_spi3_sck_pin, Spi3, SpiSckPin),
         ]
     }
     (Pio0_7, pio0_7): {
@@ -475,11 +477,13 @@ special_pins! {
     (Pio0_7, pio0_7): {
         (3, FC5_SCK): [
             (into_usart5_sclk_pin, Usart5, UsartSclkPin),
+            (into_spi5_sck_pin, Spi5, SpiSckPin),
         ]
     }
     (Pio0_7, pio0_7): {
         (4, FC1_SCK): [
             (into_usart1_sclk_pin, Usart1, UsartSclkPin),
+            (into_spi1_sck_pin, Spi1, SpiSckPin),
         ]
     }
     (Pio0_8, pio0_8): {
@@ -511,6 +515,7 @@ special_pins! {
     (Pio0_10, pio0_10): {
         (1, FC6_SCK): [
             (into_usart6_sclk_pin, Usart6, UsartSclkPin),
+            (into_spi6_sck_pin, Spi6, SpiSckPin),
         ]
     }
     (Pio0_10, pio0_10): {
@@ -647,6 +652,7 @@ special_pins! {
     (Pio0_21, pio0_21): {
         (7, FC7_SCK): [
             (into_usart7_sclk_pin, Usart7, UsartSclkPin),
+            (into_spi7_sck_pin, Spi7, SpiSckPin),
         ]
     }
     (Pio0_22, pio0_22): {
@@ -691,6 +697,7 @@ special_pins! {
     (Pio0_26, pio0_26): {
         (8, FC0_SCK): [
             (into_usart0_sclk_pin, Usart0, UsartSclkPin),
+            (into_spi0_sck_pin, Spi0, SpiSckPin),
         ]
     }
     (Pio0_26, pio0_26): {
@@ -717,6 +724,7 @@ special_pins! {
     (Pio0_28, pio0_28): {
         (1, FC0_SCK): [
             (into_usart0_sclk_pin, Usart0, UsartSclkPin),
+            (into_spi0_sck_pin, Spi0, SpiSckPin),
         ]
     }
     (Pio0_29, pio0_29): {
@@ -775,6 +783,7 @@ special_pins! {
     (Pio1_4, pio1_4): {
         (1, FC0_SCK): [
             (into_usart0_sclk_pin, Usart0, UsartSclkPin),
+            (into_spi0_sck_pin, Spi0, SpiSckPin),
         ]
     }
     (Pio1_5, pio1_5): {
@@ -815,6 +824,7 @@ special_pins! {
     (Pio1_9, pio1_9): {
         (2, FC1_SCK): [
             (into_usart1_sclk_pin, Usart1, UsartSclkPin),
+            (into_spi1_sck_pin, Spi1, SpiSckPin),
         ]
     }
     (Pio1_9, pio1_9): {
@@ -843,6 +853,7 @@ special_pins! {
     (Pio1_12, pio1_12): {
         (2, FC6_SCK): [
             (into_usart6_sclk_pin, Usart6, UsartSclkPin),
+            (into_spi6_sck_pin, Spi6, SpiSckPin),
         ]
     }
     (Pio1_12, pio1_12): {
@@ -897,6 +908,7 @@ special_pins! {
     (Pio1_19, pio1_19): {
         (5, FC4_SCK): [
             (into_usart4_sclk_pin, Usart4, UsartSclkPin),
+            (into_spi4_sck_pin, Spi4, SpiSckPin),
         ]
     }
     (Pio1_20, pio1_20): {
@@ -937,6 +949,7 @@ special_pins! {
     (Pio1_23, pio1_23): {
         (1, FC2_SCK): [
             (into_usart2_sclk_pin, Usart2, UsartSclkPin),
+            (into_spi2_sck_pin, Spi2, SpiSckPin),
         ]
     }
     (Pio1_23, pio1_23): {
@@ -987,6 +1000,7 @@ special_pins! {
     (Pio1_28, pio1_28): {
         (1, FC7_SCK): [
             (into_usart7_sclk_pin, Usart7, UsartSclkPin),
+            (into_spi7_sck_pin, Spi7, SpiSckPin),
         ]
     }
     (Pio1_29, pio1_29): {
@@ -1055,25 +1069,6 @@ impl<PIO: PinId> fc::I2sWsPin<PIO, flexcomm::I2s4> for Pin<PIO, Special<function
 impl<PIO: PinId> fc::I2sWsPin<PIO, flexcomm::I2s5> for Pin<PIO, Special<function::FC5_TXD_SCL_MISO_WS>> {}
 impl<PIO: PinId> fc::I2sWsPin<PIO, flexcomm::I2s6> for Pin<PIO, Special<function::FC6_TXD_SCL_MISO_WS>> {}
 impl<PIO: PinId> fc::I2sWsPin<PIO, flexcomm::I2s7> for Pin<PIO, Special<function::FC7_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi0> for Pin<PIO, Special<function::FC0_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi1> for Pin<PIO, Special<function::FC1_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi2> for Pin<PIO, Special<function::FC2_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi3> for Pin<PIO, Special<function::FC3_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi4> for Pin<PIO, Special<function::FC4_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi5> for Pin<PIO, Special<function::FC5_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi6> for Pin<PIO, Special<function::FC6_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi7> for Pin<PIO, Special<function::FC7_TXD_SCL_MISO_WS>> {}
-impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_MISO>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi0> for Pin<PIO, Special<function::FC0_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi1> for Pin<PIO, Special<function::FC1_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi2> for Pin<PIO, Special<function::FC2_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi3> for Pin<PIO, Special<function::FC3_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi4> for Pin<PIO, Special<function::FC4_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi5> for Pin<PIO, Special<function::FC5_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi6> for Pin<PIO, Special<function::FC6_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi7> for Pin<PIO, Special<function::FC7_RXD_SDA_MOSI_DATA>> {}
-impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_MOSI>> {}
-impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_SCK>> {}
 impl<PIO: PinId> fc::SpiCsPin<PIO, flexcomm::Spi0> for Pin<PIO, Special<function::FC0_CTS_SDA_SSEL0>> {
     const CS: ChipSelect = ChipSelect::Chip0;
 }
@@ -1146,6 +1141,33 @@ impl<PIO: PinId> fc::SpiCsPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function
 impl<PIO: PinId> fc::SpiCsPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_SSEL3>> {
     const CS: ChipSelect = ChipSelect::Chip3;
 }
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi0> for Pin<PIO, Special<function::FC0_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi1> for Pin<PIO, Special<function::FC1_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi2> for Pin<PIO, Special<function::FC2_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi3> for Pin<PIO, Special<function::FC3_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi4> for Pin<PIO, Special<function::FC4_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi5> for Pin<PIO, Special<function::FC5_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi6> for Pin<PIO, Special<function::FC6_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi7> for Pin<PIO, Special<function::FC7_TXD_SCL_MISO_WS>> {}
+impl<PIO: PinId> fc::SpiMisoPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_MISO>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi0> for Pin<PIO, Special<function::FC0_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi1> for Pin<PIO, Special<function::FC1_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi2> for Pin<PIO, Special<function::FC2_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi3> for Pin<PIO, Special<function::FC3_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi4> for Pin<PIO, Special<function::FC4_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi5> for Pin<PIO, Special<function::FC5_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi6> for Pin<PIO, Special<function::FC6_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi7> for Pin<PIO, Special<function::FC7_RXD_SDA_MOSI_DATA>> {}
+impl<PIO: PinId> fc::SpiMosiPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_MOSI>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi0> for Pin<PIO, Special<function::FC0_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi1> for Pin<PIO, Special<function::FC1_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi2> for Pin<PIO, Special<function::FC2_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi3> for Pin<PIO, Special<function::FC3_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi4> for Pin<PIO, Special<function::FC4_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi5> for Pin<PIO, Special<function::FC5_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi6> for Pin<PIO, Special<function::FC6_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi7> for Pin<PIO, Special<function::FC7_SCK>> {}
+impl<PIO: PinId> fc::SpiSckPin<PIO, flexcomm::Spi8> for Pin<PIO, Special<function::HS_SPI_SCK>> {}
 impl<PIO: PinId> fc::UsartCtsPin<PIO, flexcomm::Usart0> for Pin<PIO, Special<function::FC0_CTS_SDA_SSEL0>> {}
 impl<PIO: PinId> fc::UsartCtsPin<PIO, flexcomm::Usart1> for Pin<PIO, Special<function::FC1_CTS_SDA_SSEL0>> {}
 impl<PIO: PinId> fc::UsartCtsPin<PIO, flexcomm::Usart2> for Pin<PIO, Special<function::FC2_CTS_SDA_SSEL0>> {}

--- a/src/drivers/pins.rs
+++ b/src/drivers/pins.rs
@@ -222,7 +222,8 @@ macro_rules! analog_pins {
         $number:expr,
         $type:expr,
         $default_state_ty:ty,
-        $default_state_val:expr;
+        $default_state_val:expr,
+        $channel:expr;
     )*) => {
         /// Transition pin to Analog input
         $(
@@ -231,7 +232,7 @@ macro_rules! analog_pins {
                     self,
                     iocon: &mut Iocon<init_state::Enabled>,
                     _: &mut Gpio<init_state::Enabled>,
-                ) -> Pin<$pin, state::Gpio<direction::Input>> {
+                ) -> Pin<$pin, state::Analog<direction::Input>> {
 
                     // TODO: need to set FUNC to 0 at minimum
                     iocon.raw.$field.modify(|_, w| w
@@ -243,17 +244,13 @@ macro_rules! analog_pins {
                         .od().normal() // OPENDRAIN_DI, open drain is disabled
                         .asw().set_bit() // ASW, analog input enabled
                     );
+                    
+                    // self.state.dirclr[T::PORT].write(|w| unsafe { w.dirclrp().bits(T::MASK) });
                     let pin = Pin {
                         id: self.id,
-                        state: state::Gpio {
-                            // b: RegClusterProxy::new(),
-                            // w: RegClusterProxy::new(),
-                            dirset: RegClusterProxy::new(),
+                        state: state::Analog{
+                            channel: $channel,
                             dirclr: RegClusterProxy::new(),
-                            pin: RegClusterProxy::new(),
-                            set: RegClusterProxy::new(),
-                            clr: RegClusterProxy::new(),
-
                             _direction: direction::Unknown,
                         },
                     };
@@ -335,24 +332,24 @@ pins!(
 );
 
 analog_pins!(
-    pio0_0 , Pio0_0 , 0,  0, PinType::A, state::Unused, state::Unused;
-    pio0_9 , Pio0_9 , 0,  9, PinType::A, state::Unused, state::Unused;
-    pio0_10, Pio0_10, 0, 10, PinType::A, state::Unused, state::Unused;
+    pio0_0 , Pio0_0 , 0,  0, PinType::A, state::Unused, state::Unused, 0u8;     // A = 0, B = 1, ...
+    pio0_9 , Pio0_9 , 0,  9, PinType::A, state::Unused, state::Unused, 1u8;
+    pio0_10, Pio0_10, 0, 10, PinType::A, state::Unused, state::Unused, 1u8;
     pio0_11, Pio0_11, 0, 11, PinType::A, state::Special<function::SWCLK>,
-        state::Special{ _function: function::SWCLK {} };
+        state::Special{ _function: function::SWCLK {} }, 9u8;
     pio0_12, Pio0_12, 0, 12, PinType::A, state::Special<function::SWDIO>,
-        state::Special{ _function: function::SWDIO {} };
-    pio0_15, Pio0_15, 0, 15, PinType::A, state::Unused, state::Unused;
-    pio0_16, Pio0_16, 0, 16, PinType::A, state::Unused, state::Unused;
-    pio0_18, Pio0_18, 0, 18, PinType::A, state::Unused, state::Unused;
-    pio0_23, Pio0_23, 0, 23, PinType::A, state::Unused, state::Unused;
-    pio0_31, Pio0_31, 0, 31, PinType::A, state::Unused, state::Unused;
+        state::Special{ _function: function::SWDIO {} }, 10u8;
+    pio0_15, Pio0_15, 0, 15, PinType::A, state::Unused, state::Unused, 2u8;
+    pio0_16, Pio0_16, 0, 16, PinType::A, state::Unused, state::Unused, 8u8;
+    pio0_18, Pio0_18, 0, 18, PinType::A, state::Unused, state::Unused, 2u8;
+    pio0_23, Pio0_23, 0, 23, PinType::A, state::Unused, state::Unused, 0u8;
+    pio0_31, Pio0_31, 0, 31, PinType::A, state::Unused, state::Unused, 3u8;
 
-    pio1_0 , Pio1_0 , 1,  0, PinType::A, state::Unused, state::Unused;
-    pio1_8 , Pio1_8 , 1,  8, PinType::A, state::Unused, state::Unused;
-    pio1_9 , Pio1_9 , 1,  9, PinType::A, state::Unused, state::Unused;
-    pio1_14, Pio1_14, 1, 14, PinType::A, state::Unused, state::Unused;
-    pio1_19, Pio1_19, 1, 19, PinType::A, state::Unused, state::Unused;
+    pio1_0 , Pio1_0 , 1,  0, PinType::A, state::Unused, state::Unused, 11u8;
+    pio1_8 , Pio1_8 , 1,  8, PinType::A, state::Unused, state::Unused, 4u8;
+    pio1_9 , Pio1_9 , 1,  9, PinType::A, state::Unused, state::Unused, 12u8;
+    pio1_14, Pio1_14, 1, 14, PinType::A, state::Unused, state::Unused, 3u8;
+    pio1_19, Pio1_19, 1, 19, PinType::A, state::Unused, state::Unused, 0xffu8;   // ACMP_ref
 );
 
 macro_rules! special_pins {

--- a/src/drivers/pins/gpio.rs
+++ b/src/drivers/pins/gpio.rs
@@ -160,3 +160,33 @@ where
     }
 }
 
+
+impl<T, D> Pin<T, state::Analog<D>>
+where
+    T: PinId,
+    D: direction::NotInput,
+{
+    pub fn into_input(self, ) -> Pin<T, state::Analog<direction::Input>> {
+
+        // currently, `into_gpio_pin()` sets `.digimode().digital()` in IOCON,
+        // meaning input is enabled for all pins
+
+        self.state.dirclr[T::PORT].write(|w| unsafe { w.dirclrp().bits(T::MASK) });
+
+        Pin {
+            id: self.id,
+
+            state: state::Analog {
+                channel: self.state.channel,
+                dirclr: RegClusterProxy::new(),
+                _direction: direction::Input,
+            },
+        }
+    }
+}
+
+
+
+
+
+

--- a/src/drivers/pins/gpio.rs
+++ b/src/drivers/pins/gpio.rs
@@ -166,7 +166,7 @@ where
     T: PinId,
     D: direction::NotInput,
 {
-    pub fn into_input(self, ) -> Pin<T, state::Analog<direction::Input>> {
+    pub fn into_input(self) -> Pin<T, state::Analog<direction::Input>> {
 
         // currently, `into_gpio_pin()` sets `.digimode().digital()` in IOCON,
         // meaning input is enabled for all pins

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -15,6 +15,8 @@ use crate::{
     }
 };
 
+/// Return the current time elapsed for the timer.
+/// If the timer has not started or stopped, this unit may not be accurate.
 pub trait Lap <Unit>{
     fn lap(&self) -> Unit;
 }

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -9,6 +9,11 @@ use crate::peripherals::ctimer::{
 use crate::time::{
     MicroSeconds
 };
+use crate::{
+    typestates::{
+        init_state,
+    }
+};
 
 pub trait Lap <Unit>{
     fn lap(&self) -> Unit;
@@ -16,13 +21,13 @@ pub trait Lap <Unit>{
 
 pub struct Timer<TIMER>
 where
-    TIMER: Ctimer,
+    TIMER: Ctimer<init_state::Enabled>,
 {
     timer: TIMER,
 }
 
 impl <TIMER> Timer<TIMER>
-where TIMER: Ctimer {
+where TIMER: Ctimer<init_state::Enabled> {
 
     pub fn new(timer: TIMER) -> Self{
         Self {
@@ -39,7 +44,7 @@ where TIMER: Ctimer {
 type TimeUnits = MicroSeconds;
 
 impl <TIMER> Lap<TimeUnits> for Timer<TIMER>
-where TIMER: Ctimer {
+where TIMER: Ctimer<init_state::Enabled> {
     fn lap(&self) -> TimeUnits{
         MicroSeconds(self.timer.tc.read().bits())
     }
@@ -47,7 +52,7 @@ where TIMER: Ctimer {
 
 
 impl<TIMER> timer::CountDown for Timer<TIMER> 
-where TIMER: Ctimer
+where TIMER: Ctimer<init_state::Enabled>
 {
     type Time = TimeUnits;
 
@@ -91,7 +96,7 @@ where TIMER: Ctimer
 }
 
 impl<TIMER> timer::Cancel for Timer<TIMER>
-where TIMER: Ctimer
+where TIMER: Ctimer<init_state::Enabled>
 {
     type Error = Infallible;
     fn cancel(&mut self) -> Result<(), Self::Error>{

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -1,0 +1,36 @@
+use crate::traits::wg::timer;
+
+use crate::typestates::{
+    init_state,
+};
+use crate::peripherals::ctimer::{
+    Ctimer
+};
+
+pub struct Timer<TIMER>
+where
+    TIMER: Ctimer,
+{
+    timer: TIMER,
+}
+
+impl <TIMER> Timer<TIMER>
+where TIMER: Ctimer {
+
+    pub fn new(timer: TIMER) -> Self{
+        Self {
+            timer: timer,
+        }
+    }
+
+    pub fn release(self) -> (TIMER) {
+        self.timer
+    }
+
+}
+
+// impl<TIMER> timer::CountDown for Timer<TIMER> 
+// where TIMER: Ctimer
+// {
+//     type Time = MicroSeconds
+// }

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -10,13 +10,16 @@ use crate::time::{
     MicroSeconds
 };
 
+pub trait Lap <Unit>{
+    fn lap(&self) -> Unit;
+}
+
 pub struct Timer<TIMER>
 where
     TIMER: Ctimer,
 {
     timer: TIMER,
 }
-
 
 impl <TIMER> Timer<TIMER>
 where TIMER: Ctimer {
@@ -34,9 +37,10 @@ where TIMER: Ctimer {
 }
 
 type TimeUnits = MicroSeconds;
-impl <TIMER> Timer<TIMER>
+
+impl <TIMER> Lap<TimeUnits> for Timer<TIMER>
 where TIMER: Ctimer {
-    pub fn lap(&self) -> TimeUnits{
+    fn lap(&self) -> TimeUnits{
         MicroSeconds(self.timer.tc.read().bits())
     }
 }

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -68,13 +68,17 @@ where TIMER: Ctimer
 
         // Start timer
         self.timer.tcr.write(|w| {
-            w.cen().set_bit()
-            .crst().clear_bit()
+            w.crst().clear_bit()
+            .cen().set_bit()
         });
     }
 
     fn wait(&mut self) -> nb::Result<(), Void> {
         if self.timer.ir.read().mr0int().bit_is_set() {
+            self.timer.tcr.write(|w| {
+                w.crst().set_bit()
+                .cen().clear_bit()
+            });
             return Ok(());
         }
 
@@ -88,7 +92,8 @@ where TIMER: Ctimer
     type Error = Infallible;
     fn cancel(&mut self) -> Result<(), Self::Error>{
         self.timer.tcr.write(|w| {
-            w.crst().clear_bit()
+            w.crst().set_bit()
+            .cen().clear_bit()
         });
         Ok(())
     }

--- a/src/drivers/touch.rs
+++ b/src/drivers/touch.rs
@@ -1,22 +1,12 @@
 use core::ops::{Deref, DerefMut};
 use crate::drivers::{
-    Timer,
     Pin,
+    pins,
 };
-use crate::traits::{
-    wg::{
-        digital::v2::{
-            StatefulOutputPin,
-            OutputPin,
-        },
-        timer::{
-            Cancel,
-            CountDown,
-        }
-    }
-};
+
 use crate::peripherals::{
-    ctimer::Ctimer,
+    ctimer,
+    dma::Dma,
 };
 use crate::typestates::{
     pin::{
@@ -29,30 +19,32 @@ use crate::typestates::{
 use crate::{
     typestates::{
         init_state,
-        ClocksSupportTouchToken,
     }
 };
-use crate::time::MicroSeconds;
-use crate::prelude::*;
-use crate::drivers::timer::Lap;
+
+pub struct ButtonPins<P1 : PinId, P2 :  PinId, P3 : PinId>(
+    pub Pin<P1, state::Analog<direction::Input>>, 
+    pub Pin<P2, state::Analog<direction::Input>>, 
+    pub Pin<P3, state::Analog<direction::Input>>, 
+);
 
 type Adc = crate::peripherals::adc::Adc<init_state::Enabled>;
 
-type Result<T> = core::result::Result<T, ()>;
 
-// Pin<T, state::Gpio<direction::Output>>
-pub struct TouchSensor<C: Ctimer>
-where
+pub struct TouchSensor<P1 : PinId, P2 :  PinId, P3 : PinId, 
+// State : init_state::InitState
+>
 {
-    timer: Timer<C>,
+    threshold: u32,
     adc: Adc,
-    high_threshold: u16,
-    low_threshold: u16,
+    ctimer: ctimer::Ctimer1<init_state::Enabled>,
+    buttons: ButtonPins<P1,P2,P3>,
+    results: [u32; 112],
+    // pub _state: State,
 }
 
-impl<C> Deref for TouchSensor<C>
-where
-    C: Ctimer,
+impl<P1,P2,P3> Deref for TouchSensor<P1, P2, P3>
+where P1: PinId, P2: PinId, P3: PinId
 {
     type Target = Adc;
     fn deref(&self) -> &Self::Target {
@@ -60,86 +52,187 @@ where
     }
 }   
 
-impl<C> DerefMut for TouchSensor<C>
-where
-    C: Ctimer,
+impl<P1,P2,P3> DerefMut for TouchSensor<P1, P2, P3>
+where P1: PinId, P2: PinId, P3: PinId
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.adc
     }
 }   
 
-impl<C> TouchSensor<C>
-where
-    C: Ctimer,
+impl<P1,P2,P3, > TouchSensor<P1, P2, P3, >
+where P1: PinId, P2: PinId, P3: PinId
 {
-    pub fn new(mut adc: Adc, timer: Timer<C>, pin: & Pin<impl PinId, state::Special<function::CTIMER_MAT>>, 
-        low_threshold: u16, high_threshold: u16, _token: ClocksSupportTouchToken) -> Result<Self> {
+    pub fn new(
+                threshold: u32, 
+                adc: Adc, 
+                ctimer: ctimer::Ctimer1<init_state::Enabled>, 
+                _charge_pin: Pin<pins::Pio1_16, state::Special<function::CTIMER_MAT>>, 
+                buttons: ButtonPins<P1,P2,P3>,
+            ) -> Self {
 
-        // pin.set_low()?;
+        // Last match (3) triggers MAT to TOGGLE (start charging or discharging), interrupt ADC trigger.
+        ctimer.mcr.write(|w| {
+            w
+            .mr3i().set_bit()           // enable interrupt
+            .mr3r().set_bit()           // reset timer
+            .mr3s().clear_bit()         // do not stop.
+        } );
 
-       
-        Ok(Self {
+        ctimer.emr.write(|w| {
+            w
+            .emc3().toggle()               // match 3 charge
+        });
+
+        // MR3 starts charge or discharge.  should give ample time to either charge or discharge;
+        ctimer.mr[3].write(|w| unsafe { w.bits(800) });
+
+        // Clear mr3 interrupt.  Setting bit clears it.
+        ctimer.ir.write(|w| { w.mr3int().set_bit() });
+
+        // ADC trigger 6 activates from ctimer1 mat3
+        adc.tctrl[6].write(|w| unsafe {
+            w.hten().set_bit()
+            .fifo_sel_a().fifo_sel_a_0()
+            .fifo_sel_b().fifo_sel_b_0()
+            .tcmd().bits(3)                 // Target cmd 3
+            .tpri().bits(2)
+        });
+
+
+        adc.cmdl3.write(|w| unsafe {  w.adch().bits(buttons.0.state.channel)
+                                    .ctype().ctype_0()          // A-side single ended 
+                                    .mode().mode_0()            // standard 12-bit resolution
+                                    } );
+        adc.cmdh3.write(|w| unsafe { w.avgs().avgs_7()          // 2^7 averages
+                                    .cmpen().bits(0b00)         // no compare
+                                    .loop_().bits(0)            // execute once
+                                    .next().bits(4)             // 3 -> 4
+                                    .wait_trig().set_bit()      // wait for trigger again
+                                } );
+
+
+        adc.cmdl4.write(|w| unsafe {  w.adch().bits(buttons.1.state.channel)
+                                    .ctype().ctype_0()  
+                                    .mode().mode_0()
+                                    } );
+        adc.cmdh4.write(|w| unsafe { w.avgs().avgs_7()
+                                    .cmpen().bits(0b00)
+                                    .loop_().bits(0)
+                                    .next().bits(5)             // 4 -> 5
+                                    .wait_trig().set_bit()
+                                } );
+
+
+        adc.cmdl5.write(|w| unsafe {  w.adch().bits(buttons.2.state.channel)
+                                    .ctype().ctype_0()  
+                                    .mode().mode_0()
+                                    } );
+        adc.cmdh5.write(|w| unsafe { w.avgs().avgs_7()
+                                    .loop_().bits(0)
+                                    .next().bits(3)             // 5 -> 3
+                                    .wait_trig().set_bit()
+                                } );
+
+
+
+
+        Self {
             adc: adc,
-            timer: timer,
-            high_threshold: high_threshold,
-            low_threshold: low_threshold,
-        })
-    }
-
-    pub fn discharge(&mut self) -> Result<()>{
-        // self.charge_pin.set_low()?;
-        Ok(())
-    }
-
-    pub fn charge(&mut self) -> Result<()>{
-        // self.charge_pin.set_high()?;
-        Ok(())
+            ctimer: ctimer,
+            buttons: buttons,
+            threshold: threshold,
+            results: [0u32; 112],
+            // _state: init_state::Unknown,
+        }
     }
 
 
+}
 
-    pub fn measure(&mut self, channel: &Pin<impl PinId, state::Analog<direction::Input>>) -> Result<MicroSeconds> {
-        // assert!(self.charge_pin.is_set_low()?);
 
-        self.arm_comparator_channel(channel.state.channel);
+impl<P1,P2,P3,> TouchSensor<P1, P2, P3, >
+where P1: PinId, P2: PinId, P3: PinId, 
+{
+    // Starts timer and DMA to enable touch detection
+    pub fn enabled(
+                mut self,
+                dma: &mut Dma<init_state::Enabled>,
+            ) -> Self //<init_state::Enabled>
+            {
 
-        // Compare high threshold
-        self.adc.set_threshold(0, self.high_threshold);
- 
-        self.timer.start(3.ms());
+        dma.configure_adc(&mut self.adc, &mut self.results);
 
-        //get sample + start charge
-        self.adc.swtrig.write(|w| unsafe {w.bits(1)});
-        // self.charge_pin.set_high()?;
-        while self.fctrl[0].read().fcount().bits() == 0 {
-            if self.timer.lap().0 > 900 {
-                self.cancel_compare();
-                self.timer.cancel().ok();
-                return Ok(MicroSeconds(1000));
+        // Start timer
+        self.ctimer.tcr.write(|w| {
+            w.crst().clear_bit()
+            .cen().set_bit()
+        });
+
+        self
+    }
+}
+
+#[derive(PartialEq)]
+pub enum ButtonState{
+    Pressed,
+    NotPressed
+}
+
+pub struct Buttons{
+    pub top: ButtonState,
+    pub bot: ButtonState,
+    pub mid: ButtonState,
+}
+
+
+// for Enabled TouchSensor
+impl<P1,P2,P3,> TouchSensor<P1, P2, P3, >
+where P1: PinId, P2: PinId, P3: PinId, 
+{
+
+    /// Dumb average / level-states
+    pub fn get_button_state(&self, ) -> Buttons{
+        let mut buts = Buttons{top: ButtonState::NotPressed, bot: ButtonState::NotPressed, mid: ButtonState::NotPressed};
+        let results = self.results;
+
+        let mut counts = [0u32; 3];
+        let mut sums = [0u32; 3];
+
+        // calculate running average for three buttons.
+        // readings for each are mixed in the array.
+        for i in 0 .. results.len() {
+            let res = results[i];
+            let sample = res & 0xffff;
+            let src = ((res & (0xf << 24)) >> 24) as u8;
+
+            if src == self.buttons.0.state.channel {
+                counts[0] += 1;
+                sums[0] += sample;
+            }
+            else if src == self.buttons.1.state.channel {
+                counts[1] += 1;
+                sums[1] += sample;
+            }
+            else if src == self.buttons.2.state.channel {
+                counts[2] += 1;
+                sums[2] += sample;
+            }
+            else {
+                assert!(false);
             }
         }
-        let result = self.resfifo[0].read().bits();
-        assert!( (result & 0x80000000) != 0 );
 
-        // 
-        // self.adc.set_threshold(self.low_threshold, 0x7fff);
-        // self.adc.swtrig.write(|w| unsafe {w.bits(1)});
-        // self.charge_pin.set_low()?;
-        // while self.fctrl[0].read().fcount().bits() == 0 {
-        //     if self.timer.lap().0 > 1900 {
-        //         self.cancel_compare();
-        //         self.timer.cancel().ok();
-        //         return Ok(MicroSeconds(2000));
-        //     }
-        // }
-        // let result = self.resfifo[0].read().bits();
-        // assert!( (result & 0x80000000) != 0 );
+        if sums[0]/counts[0] < self.threshold {
+            buts.top = ButtonState::Pressed;
+        }
+        if sums[1]/counts[1] < self.threshold {
+            buts.bot= ButtonState::Pressed;
+        }
+        if sums[2]/counts[2] < self.threshold {
+            buts.mid = ButtonState::Pressed;
+        }
 
-        let duration = self.timer.lap();
-        self.timer.cancel().ok();
-
-        Ok(duration)
+        buts
     }
-
 }

--- a/src/drivers/touch.rs
+++ b/src/drivers/touch.rs
@@ -1,0 +1,120 @@
+use core::ops::{Deref, DerefMut};
+use crate::drivers::{
+    Timer,
+    Pin,
+};
+use crate::traits::{
+    wg::{
+        digital::v2::{
+            StatefulOutputPin,
+            OutputPin,
+        },
+        timer::{
+            Cancel,
+            CountDown,
+        }
+    }
+};
+use crate::peripherals::{
+    ctimer::Ctimer,
+};
+use crate::typestates::{
+    pin::PinId,
+    pin::state,
+    pin::gpio::direction,
+};
+use crate::{
+    typestates::{
+        init_state,
+    }
+};
+use crate::time::MicroSeconds;
+use crate::prelude::*;
+use crate::drivers::timer::Lap;
+
+type Adc = crate::peripherals::adc::Adc<init_state::Enabled>;
+
+type Result<T, PIN > = core::result::Result<T, <PIN as OutputPin>::Error>;
+
+// Pin<T, state::Gpio<direction::Output>>
+pub struct TouchSensor<PIN, C: Ctimer>
+where
+    PIN: OutputPin + StatefulOutputPin,
+{
+    timer: Timer<C>,
+    adc: Adc,
+    charge_pin: PIN,
+}
+
+impl<PIN, C> Deref for TouchSensor<PIN, C>
+where
+    PIN: OutputPin + StatefulOutputPin,
+    C: Ctimer,
+{
+    type Target = Adc;
+    fn deref(&self) -> &Self::Target {
+        &self.adc
+    }
+}   
+
+impl<PIN, C> DerefMut for TouchSensor<PIN, C>
+where
+    PIN: OutputPin + StatefulOutputPin,
+    C: Ctimer,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.adc
+    }
+}   
+
+impl<PIN, C> TouchSensor<PIN, C>
+where
+    PIN: OutputPin + StatefulOutputPin,
+    C: Ctimer,
+{
+    pub fn new(mut adc: Adc, timer: Timer<C>, mut pin: PIN, threshold: u16) -> Result<Self, PIN> {
+
+        pin.set_low()?;
+
+        // Configure compare operation to (result > CThreshold ? true : false)
+        adc.set_threshold(0, threshold);
+        
+        Ok(Self {
+            adc: adc,
+            timer: timer,
+            charge_pin: pin,
+        })
+    }
+
+    pub fn discharge(&mut self) -> Result<(), PIN>{
+        self.charge_pin.set_low()?;
+        Ok(())
+    }
+
+    pub fn measure(&mut self, channel: &Pin<impl PinId, state::Analog<direction::Input>>) -> Result<MicroSeconds, PIN> {
+        assert!(self.charge_pin.is_set_low()?);
+
+        self.arm_comparator_channel(channel.state.channel);
+        self.raw.cmdl1.read().bits();
+        self.timer.start(1.ms());
+
+        //get sample + start charge
+        self.adc.swtrig.write(|w| unsafe {w.bits(1)});
+        self.charge_pin.set_high()?;
+        while self.fctrl[0].read().fcount().bits() == 0 {
+            if self.timer.lap().0 > 900 {
+                self.cancel_compare();
+                self.timer.cancel().ok();
+                return Ok(MicroSeconds(1000));
+            }
+        }
+        let result = self.resfifo[0].read().bits();
+        assert!( (result & 0x80000000) != 0 );
+
+        let duration = self.timer.lap();
+        self.timer.cancel().ok();
+
+        Ok(duration)
+    }
+
+}

--- a/src/drivers/touch.rs
+++ b/src/drivers/touch.rs
@@ -12,6 +12,7 @@ use crate::{
             gpio::direction,
         },
         init_state,
+        ClocksSupportTouchToken,
     },
     drivers::{
         Pin,
@@ -188,6 +189,7 @@ where P1: PinId, P2: PinId, P3: PinId,
     pub fn enabled(
                 mut self,
                 dma: &mut Dma<init_state::Enabled>,
+                _token: ClocksSupportTouchToken,
             ) -> Self //<init_state::Enabled>
             {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub use peripherals::{
     anactrl::Anactrl,
     casper::Casper,
     ctimer::Ctimers,
+    dma::Dma,
     flash::Flash,
     flexcomm::Flexcomm,
     gpio::Gpio,
@@ -151,6 +152,9 @@ pub struct Peripherals {
     /// Standard counter/timer (CTIMER)
     pub ctimer: Ctimers,
 
+    /// Direct memory access
+    pub DMA0: raw::DMA0,
+
     pub FLASH_CMPA: raw::FLASH_CMPA,
     pub FLASH_CFPA0: raw::FLASH_CFPA0,
 
@@ -220,6 +224,7 @@ impl From<(raw::Peripherals, rtfm::Peripherals)> for Peripherals {
             // Raw peripherals
             ADC0: p.ADC0,
             CRC_ENGINE: p.CRC_ENGINE,
+            DMA0: p.DMA0,
             FLASH_CMPA: p.FLASH_CMPA,
             FLASH_CFPA0: p.FLASH_CFPA0,
             SCT0: p.SCT0,
@@ -274,6 +279,7 @@ impl From<(raw::Peripherals, raw::CorePeripherals)> for Peripherals {
             // Raw peripherals
             ADC0: p.ADC0,
             CRC_ENGINE: p.CRC_ENGINE,
+            DMA0: p.DMA0,
             FLASH_CMPA: p.FLASH_CMPA,
             FLASH_CFPA0: p.FLASH_CFPA0,
             SCT0: p.SCT0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,10 @@ pub use typestates::{
 
 pub mod peripherals;
 pub use peripherals::{
+    adc::Adc,
     anactrl::Anactrl,
     casper::Casper,
+    ctimer::Ctimer,
     flash::Flash,
     flexcomm::Flexcomm,
     gpio::Gpio,
@@ -64,7 +66,6 @@ pub use peripherals::{
     syscon::Syscon,
     usbfs::Usbfs,
     utick::Utick,
-    adc::Adc,
 };
 
 pub mod drivers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use peripherals::{
     adc::Adc,
     anactrl::Anactrl,
     casper::Casper,
-    ctimer::Ctimer,
+    ctimer::Ctimers,
     flash::Flash,
     flexcomm::Flexcomm,
     gpio::Gpio,
@@ -148,8 +148,8 @@ pub struct Peripherals {
     /// CRC engine - not HAL-ified.
     pub CRC_ENGINE: raw::CRC_ENGINE,
 
-    /// Standard counter/timer (CTIMER) - not HAL-ified.
-    pub CTIMER0: raw::CTIMER0,
+    /// Standard counter/timer (CTIMER)
+    pub ctimer: Ctimers,
 
     pub FLASH_CMPA: raw::FLASH_CMPA,
     pub FLASH_CFPA0: raw::FLASH_CFPA0,
@@ -190,6 +190,13 @@ impl From<(raw::Peripherals, rtfm::Peripherals)> for Peripherals {
             // HAL peripherals
             anactrl: Anactrl::from(p.ANACTRL),
             casper: Casper::from(p.CASPER),
+            ctimer: (
+                peripherals::ctimer::Ctimer0::from(raw::CTIMER0),
+                peripherals::ctimer::Ctimer1::from(raw::CTIMER1),
+                peripherals::ctimer::Ctimer2::from(raw::CTIMER2),
+                peripherals::ctimer::Ctimer3::from(raw::CTIMER3),
+                peripherals::ctimer::Ctimer4::from(raw::CTIMER4),
+            ),
             flash: Flash::from(p.FLASH),
             flexcomm: (
                 peripherals::flexcomm::Flexcomm0::from((p.FLEXCOMM0, p.I2C0, p.I2S0, p.SPI0, p.USART0)),
@@ -213,7 +220,6 @@ impl From<(raw::Peripherals, rtfm::Peripherals)> for Peripherals {
             // Raw peripherals
             ADC0: p.ADC0,
             CRC_ENGINE: p.CRC_ENGINE,
-            CTIMER0: p.CTIMER0,
             FLASH_CMPA: p.FLASH_CMPA,
             FLASH_CFPA0: p.FLASH_CFPA0,
             SCT0: p.SCT0,
@@ -237,6 +243,14 @@ impl From<(raw::Peripherals, raw::CorePeripherals)> for Peripherals {
             // HAL peripherals
             anactrl: Anactrl::from(p.ANACTRL),
             casper: Casper::from(p.CASPER),
+
+            ctimer: (
+                peripherals::ctimer::Ctimer0::from(p.CTIMER0),
+                peripherals::ctimer::Ctimer1::from(p.CTIMER1),
+                peripherals::ctimer::Ctimer2::from(p.CTIMER2),
+                peripherals::ctimer::Ctimer3::from(p.CTIMER3),
+                peripherals::ctimer::Ctimer4::from(p.CTIMER4),
+            ),
             flash: Flash::from(p.FLASH),
             flexcomm: (
                 peripherals::flexcomm::Flexcomm0::from((p.FLEXCOMM0, p.I2C0, p.I2S0, p.SPI0, p.USART0)),
@@ -260,7 +274,6 @@ impl From<(raw::Peripherals, raw::CorePeripherals)> for Peripherals {
             // Raw peripherals
             ADC0: p.ADC0,
             CRC_ENGINE: p.CRC_ENGINE,
-            CTIMER0: p.CTIMER0,
             FLASH_CMPA: p.FLASH_CMPA,
             FLASH_CFPA0: p.FLASH_CFPA0,
             SCT0: p.SCT0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,11 +195,11 @@ impl From<(raw::Peripherals, rtfm::Peripherals)> for Peripherals {
             anactrl: Anactrl::from(p.ANACTRL),
             casper: Casper::from(p.CASPER),
             ctimer: (
-                peripherals::ctimer::Ctimer0::from(raw::CTIMER0),
-                peripherals::ctimer::Ctimer1::from(raw::CTIMER1),
-                peripherals::ctimer::Ctimer2::from(raw::CTIMER2),
-                peripherals::ctimer::Ctimer3::from(raw::CTIMER3),
-                peripherals::ctimer::Ctimer4::from(raw::CTIMER4),
+                peripherals::ctimer::Ctimer0::from(p.CTIMER0),
+                peripherals::ctimer::Ctimer1::from(p.CTIMER1),
+                peripherals::ctimer::Ctimer2::from(p.CTIMER2),
+                peripherals::ctimer::Ctimer3::from(p.CTIMER3),
+                peripherals::ctimer::Ctimer4::from(p.CTIMER4),
             ),
             flash: Flash::from(p.FLASH),
             flexcomm: (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub use peripherals::{
     syscon::Syscon,
     usbfs::Usbfs,
     utick::Utick,
+    adc::Adc,
 };
 
 pub mod drivers;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -32,3 +32,4 @@ pub mod syscon;
 pub mod usbfs;
 pub mod utick;
 pub mod adc;
+pub mod ctimer;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -19,8 +19,11 @@
 //! let syscon = hal.syscon;
 //! ```
 
+pub mod adc;
 pub mod anactrl;
 pub mod casper;
+pub mod ctimer;
+pub mod dma;
 pub mod flash;
 pub mod flexcomm;
 pub mod gint;
@@ -31,5 +34,3 @@ pub mod rng;
 pub mod syscon;
 pub mod usbfs;
 pub mod utick;
-pub mod adc;
-pub mod ctimer;

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -31,3 +31,4 @@ pub mod rng;
 pub mod syscon;
 pub mod usbfs;
 pub mod utick;
+pub mod adc;

--- a/src/peripherals/adc.rs
+++ b/src/peripherals/adc.rs
@@ -1,0 +1,50 @@
+use crate::{
+    raw,
+    peripherals::{
+        syscon::Syscon,
+    },
+    typestates::{
+        init_state,
+    }
+};
+
+crate::wrap_stateful_peripheral!(Adc, ADC0);
+
+impl<State> Adc<State> {
+    pub fn enabled(mut self, syscon: &mut Syscon) -> Adc<init_state::Enabled> {
+        syscon.enable_clock(&mut self.raw);
+        syscon.raw.adcclksel.write(|w| {w.sel().mainclk()});
+
+        self.raw.ctrl.write(|w| {w.adcen().clear_bit()}); // Turn off prior to configuration
+
+        self.raw.ctrl.write(|w| {w.rst().set_bit()});   // Reset
+        self.raw.ctrl.write(|w| {w.rst().clear_bit()});
+
+        self.raw.ctrl.write(|w| {w.rst().set_bit()});   // Reset
+        self.raw.ctrl.write(|w| {w.rst().clear_bit()});
+
+        self.raw.ctrl.write(|w| {w.rstfifo0().set_bit()});  // Reset FIFO
+        self.raw.ctrl.write(|w| {w.rstfifo0().clear_bit()});
+
+        self.raw.ctrl.write(|w| {w.rstfifo1().set_bit()});  // Reset FIFO
+        self.raw.ctrl.write(|w| {w.rstfifo1().clear_bit()});
+
+
+
+        Adc {
+            raw: self.raw,
+            _state: init_state::Enabled(()),
+        }
+    }
+
+    pub fn disabled(mut self, syscon: &mut Syscon) -> Adc<init_state::Disabled> {
+        self.raw.ctrl.write(|w| {w.adcen().clear_bit()});
+        syscon.raw.adcclksel.write(|w| {w.sel().none()});
+        syscon.disable_clock(&mut self.raw);
+
+        Adc {
+            raw: self.raw,
+            _state: init_state::Disabled,
+        }
+    }
+}

--- a/src/peripherals/adc.rs
+++ b/src/peripherals/adc.rs
@@ -71,7 +71,7 @@ impl<State> Adc<State> {
                                     .ctype().ctype_0()  
                                     .mode().mode_0()
                                     } );
-        self.raw.cmdh2.write(|w| unsafe { w.avgs().avgs_3()
+        self.raw.cmdh2.write(|w| unsafe { w.avgs().avgs_7()
                                     .cmpen().bits(0b00)        // no compare
                                     .loop_().bits(0)
                                     .next().bits(0)
@@ -83,7 +83,7 @@ impl<State> Adc<State> {
                                     .ctype().ctype_0()  
                                     .mode().mode_0()
                                     } );
-        self.raw.cmdh1.write(|w| unsafe { w.avgs().avgs_3()      // average 2^3 samples
+        self.raw.cmdh1.write(|w| unsafe { w.avgs().avgs_7()      // average 2^3 samples
                                     .cmpen().bits(0b11)        // compare repeatedly until true
                                     .loop_().bits(0)         // no loop
                                     .next().bits(0)         // no next command
@@ -227,7 +227,7 @@ impl<State> Adc <State>
         while self.raw.fctrl[0].read().fcount().bits() == 0 {
         }
         let result = self.raw.resfifo[0].read().bits();
-        if  (result & 0x80000000) != 0 {
+        if  (result & 0x80000000) == 0 {
             return Err(Underflow);
         }
         let sample = (result & 0xffff) as u16;

--- a/src/peripherals/adc.rs
+++ b/src/peripherals/adc.rs
@@ -145,7 +145,10 @@ impl<State> Adc<State> {
 
 
         // No pause for now, but could be interesting
-        self.raw.pause.write(|w| unsafe {w.bits(0)});
+        self.raw.pause.write(|w| unsafe {
+            w.pausedly().bits(0)
+            .pauseen().clear_bit()
+        });
 
         // Set 0 for watermark
         self.raw.fctrl[0].write(|w| unsafe{w.fwmark().bits(0)});

--- a/src/peripherals/adc.rs
+++ b/src/peripherals/adc.rs
@@ -1,17 +1,107 @@
+use core::ops::Deref;
 use crate::{
     raw,
     peripherals::{
         syscon::Syscon,
         pmc::Pmc,
     },
+    drivers::{
+        pins::Pin,
+    },
     typestates::{
         init_state,
+        pin::{
+            state,
+            gpio::{
+                direction,
+            },
+            PinId,
+        },
     }
 };
 
+pub enum ChannelType {
+    Comparator = 0,
+    Cancel = 1,
+    Normal = 2,
+}
+
 crate::wrap_stateful_peripheral!(Adc, ADC0);
 
+impl<State> Deref for Adc<State> {
+    type Target = raw::adc0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        &self.raw
+    }
+}   
+
 impl<State> Adc<State> {
+    fn autocal (&mut self,) {
+        // Calibration + offset trimming
+        self.raw.ofstrim.write(|w| unsafe {
+            w.ofstrim_a().bits(10)
+            .ofstrim_b().bits(10)
+        });
+
+        // Request calibration
+        self.raw.ctrl.modify(|_,w| {w.cal_req().set_bit()});
+
+        // wait for auto-cal to be ready.
+        while (!self.raw.gcc[0].read().rdy().bits()) || (!self.raw.gcc[1].read().rdy().bits()) {
+        }
+
+        let gain_a = self.raw.gcc[0].read().gain_cal().bits();
+        let gain_b = self.raw.gcc[1].read().gain_cal().bits();
+
+        let gcr_a = (((gain_a as u32) << 16) / (0x1FFFFu32 - gain_a as u32 )) as u16;
+        let gcr_b = (((gain_b as u32) << 16) / (0x1FFFFu32 - gain_b as u32 )) as u16;
+
+        self.raw.gcr[0].write(|w| unsafe {w.gcalr().bits(gcr_a)});
+        self.raw.gcr[1].write(|w| unsafe {w.gcalr().bits(gcr_b)});
+
+        self.raw.gcr[0].write(|w| {w.rdy().set_bit()});
+        self.raw.gcr[1].write(|w| {w.rdy().set_bit()});
+
+        while !self.raw.stat.read().cal_rdy().bits() {
+        }
+    }
+
+    pub fn arm_normal_channel(&mut self, channel_id: u8) {
+        self.raw.cmdl2.write(|w| unsafe {  w.adch().bits(channel_id)
+                                    .ctype().ctype_0()  
+                                    .mode().mode_0()
+                                    } );
+        self.raw.cmdh2.write(|w| unsafe { w.avgs().avgs_3()
+                                    .cmpen().bits(0b00)        // no compare
+                                    .loop_().bits(0)
+                                    .next().bits(0)
+                                } );
+    }
+
+    pub fn arm_comparator_channel(&mut self, channel_id: u8) {
+        self.raw.cmdl1.write(|w| unsafe {  w.adch().bits(channel_id)
+                                    .ctype().ctype_0()  
+                                    .mode().mode_0()
+                                    } );
+        self.raw.cmdh1.write(|w| unsafe { w.avgs().avgs_3()      // average 2^3 samples
+                                    .cmpen().bits(0b11)        // compare repeatedly until true
+                                    .loop_().bits(0)         // no loop
+                                    .next().bits(0)         // no next command
+                                } );
+    }
+
+    pub fn set_threshold(&mut self, low: u16, high: u16) {
+        self.raw.cv1.write(|w| unsafe {
+            w.cvl().bits(low)
+            .cvh().bits(high)
+        })
+    }
+
+    pub fn cancel_compare(&mut self){
+        self.raw.swtrig.write(|w| unsafe {w.bits(2)});      // Trigger the cancel trigger
+        self.raw.ctrl.modify(|_,w| { w.rstfifo0().set_bit().rstfifo1().set_bit() })
+    }
+
     pub fn enabled(mut self, pmc: &mut Pmc, syscon: &mut Syscon) -> Adc<init_state::Enabled> {
         syscon.enable_clock(&mut self.raw);
         syscon.raw.adcclkdiv.write(|w| {w.reset().set_bit()});
@@ -31,8 +121,73 @@ impl<State> Adc<State> {
         self.raw.ctrl.write(|w| {w.rstfifo1().set_bit()});  // Reset FIFO
         self.raw.ctrl.write(|w| {w.rstfifo1().clear_bit()});
 
-        self.raw.ctrl.write(|w| {w.adcen().clear_bit()}); // Turn off prior to configuration
-        self.raw.cfg.write(|w| {w.pwren().clear_bit()}); //Must be cleared prior to ADC being enabled
+        self.raw.ctrl.write(|w| {
+            w.adcen().clear_bit()  // Turn off prior to configuration
+        }); 
+        self.raw.cfg.write(|w| {
+            w.pwren().clear_bit()  //Must be cleared prior to ADC being enabled
+        }); 
+
+
+        self.raw.ctrl.write(|w| {
+            w.dozen().set_bit()
+            .cal_avgs().cal_avgs_7()
+        });
+
+        self.raw.cfg.write(|w| unsafe {
+            w.pwren().set_bit()
+            .pudly().bits(0x80)
+            .refsel().refsel_1()
+            .pwrsel().pwrsel_3()
+            .tprictrl().bits(0)
+            .tres().clear_bit() // Do not resume interrupted captures
+        });
+
+
+        // No pause for now, but could be interesting
+        self.raw.pause.write(|w| unsafe {w.bits(0)});
+
+        // Set 0 for watermark
+        self.raw.fctrl[0].write(|w| unsafe{w.fwmark().bits(0)});
+        self.raw.fctrl[1].write(|w| unsafe{w.fwmark().bits(0)});
+
+
+        // turn on!
+        self.raw.ctrl.modify(|_, w| {w.adcen().set_bit()});
+
+
+        self.autocal();
+
+        self.arm_comparator_channel(3);
+        self.arm_normal_channel(3);
+
+        // Main trigger
+        self.raw.tctrl[ChannelType::Comparator as usize].write(|w| unsafe {
+            w.hten().set_bit()
+            .fifo_sel_a().fifo_sel_a_0()
+            .fifo_sel_b().fifo_sel_b_0()
+            .tcmd().bits(1)
+            .tpri().bits(3)
+        });
+
+        // Cancel/resync trigger to main trigger
+        self.raw.tctrl[ChannelType::Cancel as usize].write(|w| unsafe {
+            w.hten().set_bit()
+            .fifo_sel_a().fifo_sel_a_0()
+            .fifo_sel_b().fifo_sel_b_0()
+            .tcmd().bits(0)
+            .rsync().set_bit()
+            .tpri().bits(0) //highest priority
+        });
+
+        // Normal measurement trigger
+        self.raw.tctrl[ChannelType::Normal as usize].write(|w| unsafe {
+            w.hten().set_bit()
+            .fifo_sel_a().fifo_sel_a_0()
+            .fifo_sel_b().fifo_sel_b_0()
+            .tcmd().bits(2)
+            .tpri().bits(2)
+        });
 
 
         Adc {
@@ -53,3 +208,29 @@ impl<State> Adc<State> {
     }
 }
 
+// use crate::traits::wg::adc;
+
+type Result<T> = core::result::Result<T, Underflow>;
+
+#[derive(Debug, Clone)]
+pub struct Underflow;
+
+impl<State> Adc <State>
+{
+    // type Error = Underflow;
+
+    // Read normal sample
+    pub fn read(&mut self, pin: & Pin<impl PinId, state::Analog<direction::Input>>) -> Result<u16> {
+        self.arm_normal_channel(pin.state.channel);
+
+        self.raw.swtrig.write(|w| unsafe {w.bits(1<<(ChannelType::Normal as usize))});
+        while self.raw.fctrl[0].read().fcount().bits() == 0 {
+        }
+        let result = self.raw.resfifo[0].read().bits();
+        if  (result & 0x80000000) != 0 {
+            return Err(Underflow);
+        }
+        let sample = (result & 0xffff) as u16;
+        Ok(sample)
+    }
+}

--- a/src/peripherals/adc.rs
+++ b/src/peripherals/adc.rs
@@ -18,7 +18,7 @@ impl<State> Adc<State> {
         syscon.raw.adcclkdiv.write(|w| unsafe {w.div().bits(0)});
         syscon.raw.adcclkdiv.write(|w| unsafe {w.bits(0)});
 
-        syscon.raw.adcclksel.write(|w| {w.sel().mainclk()});
+        syscon.raw.adcclksel.write(|w| {w.sel().fro96()});
 
         pmc.power_on(&mut self.raw);
 

--- a/src/peripherals/ctimer.rs
+++ b/src/peripherals/ctimer.rs
@@ -18,7 +18,7 @@ pub type Ctimers = (
     Ctimer4,
 );
 
-pub trait Ctimer: Deref<Target = raw::ctimer0::RegisterBlock> {}
+pub trait Ctimer<State>: Deref<Target = raw::ctimer0::RegisterBlock> {}
 
 macro_rules! ctimer {
     ($c_hal:ident, $c_pac:ident, $register:ident, $clock_input:ident) => {
@@ -31,7 +31,7 @@ macro_rules! ctimer {
             &self.raw
         }
     }   
-    impl Ctimer for $c_hal<init_state::Enabled> {}
+    impl Ctimer<init_state::Enabled> for $c_hal<init_state::Enabled> {}
     
 
     impl<State> $c_hal<State> {

--- a/src/peripherals/ctimer.rs
+++ b/src/peripherals/ctimer.rs
@@ -1,0 +1,31 @@
+use crate::{
+    raw,
+    peripherals::{
+        syscon::Syscon,
+    },
+    typestates::{
+        init_state,
+    }
+};
+
+
+
+crate::wrap_stateful_peripheral!(Ctimer, CTIMER1);
+
+impl<State> Ctimer<State> {
+    pub fn enabled(mut self, syscon: &mut Syscon) -> Ctimer <init_state::Enabled> {
+        Ctimer{
+            raw: self.raw,
+            _state: init_state::Enabled(()),
+        }
+    }
+
+    pub fn disabled(mut self, syscon: &mut Syscon) -> Ctimer <init_state::Disabled> {
+        Ctimer{
+            raw: self.raw,
+            _state: init_state::Disabled,
+        }
+    }
+}
+
+

--- a/src/peripherals/ctimer.rs
+++ b/src/peripherals/ctimer.rs
@@ -60,8 +60,8 @@ macro_rules! ctimer {
     }
 }
 
-ctimer!(Ctimer0, CTIMER0, ctimerclksel0, enum_0x0);    // 0 is main clk
-ctimer!(Ctimer1, CTIMER1, ctimerclksel1, enum_0x0);
-ctimer!(Ctimer2, CTIMER2, ctimerclksel2, enum_0x0);
-ctimer!(Ctimer3, CTIMER3, ctimerclksel3, enum_0x0);
-ctimer!(Ctimer4, CTIMER4, ctimerclksel4, enum_0x0);
+ctimer!(Ctimer0, CTIMER0, ctimerclksel0, enum_0x4);    // 4 is 1MHz FRO
+ctimer!(Ctimer1, CTIMER1, ctimerclksel1, enum_0x4);
+ctimer!(Ctimer2, CTIMER2, ctimerclksel2, enum_0x4);
+ctimer!(Ctimer3, CTIMER3, ctimerclksel3, enum_0x4);
+ctimer!(Ctimer4, CTIMER4, ctimerclksel4, enum_0x4);

--- a/src/peripherals/dma.rs
+++ b/src/peripherals/dma.rs
@@ -1,0 +1,129 @@
+use crate::{
+    raw,
+    peripherals::{
+        syscon::Syscon,
+    },
+    typestates::{
+        init_state,
+    }
+};
+
+#[repr(align(16))]
+struct Descriptor{
+    transfer_config: u32,
+    source_end_addr: u32,
+    dest_end_addr: u32,
+    next: u32,
+}
+
+#[repr(align(512))]
+struct Align512(
+    Descriptor,Descriptor,Descriptor,Descriptor,
+    Descriptor,Descriptor,Descriptor,Descriptor,
+    Descriptor,Descriptor,Descriptor,Descriptor,
+    Descriptor,Descriptor,Descriptor,Descriptor,
+
+    Descriptor,Descriptor,Descriptor,Descriptor,
+    Descriptor,Descriptor,Descriptor,Descriptor,
+    Descriptor,Descriptor,Descriptor,Descriptor,
+    Descriptor,Descriptor,Descriptor,Descriptor,
+);
+
+macro_rules! Empty {
+    () => {
+        Descriptor{transfer_config:0, source_end_addr:0, dest_end_addr:0, next:0}
+    }
+}
+
+static mut DESCRIPTORS: Align512 = Align512(
+    Empty!(),Empty!(),Empty!(),Empty!(),
+    Empty!(),Empty!(),Empty!(),Empty!(),
+    Empty!(),Empty!(),Empty!(),Empty!(),
+    Empty!(),Empty!(),Empty!(),Empty!(),
+
+    Empty!(),Empty!(),Empty!(),Empty!(),
+    Empty!(),Empty!(),Empty!(),Empty!(),
+    Empty!(),Empty!(),Empty!(),Empty!(),
+    Empty!(),Empty!(),Empty!(),Empty!(),
+);
+
+crate::wrap_stateful_peripheral!(Dma, DMA0);
+
+impl<State> Dma<State> {
+    pub fn enabled(mut self, syscon: &mut Syscon) -> Dma<init_state::Enabled> {
+        syscon.enable_clock(&mut self.raw);
+        syscon.raw.presetctrl0.modify(|_,w| { w.dma0_rst().clear_bit() });
+
+        self.raw.ctrl.write(|w| {w.enable().set_bit()});
+
+        let descriptor_addr = unsafe {
+            ((&DESCRIPTORS) as *const Align512) as u32
+        };
+
+        self.raw.srambase.write(|w|unsafe{w.bits(descriptor_addr)});
+
+        Dma {
+            raw: self.raw,
+            _state: init_state::Enabled(()),
+        }
+    }
+
+    pub fn disabled(mut self, syscon: &mut Syscon) -> Dma<init_state::Disabled> {
+        syscon.disable_clock(&mut self.raw);
+        Dma {
+            raw: self.raw,
+            _state: init_state::Disabled,
+        }
+    }
+
+    pub fn configure_adc(&mut self, adc: &mut raw::ADC0, recv_buf: &mut [u32]) {
+        assert!(recv_buf.len() < 0x3FF);
+
+        self.raw.channel21.cfg.write(|w| unsafe{
+            w
+            .periphreqen().set_bit()        // Wait when ADC is ready
+            .hwtrigen().clear_bit()         // Will run infinitely
+            .trigpol().clear_bit()          // falling edge
+            .trigtype().clear_bit()         // edge sensitive
+            .trigburst().clear_bit()
+            // .trigburst().set_bit()
+            // .burstpower().bits(3)           // Move 2^3 = 8 chunks at a time
+            .chpriority().bits(1)           // 0 highest, 7 lowest
+        });
+
+        self.raw.channel21.xfercfg.write(|w| unsafe{
+            w
+            .cfgvalid().set_bit()
+            .reload().set_bit()
+            .swtrig().clear_bit()
+            .width().bit_32()
+            .srcinc().no_increment()
+            .dstinc().width_x_1()
+            .xfercount().bits( (recv_buf.len() - 1) as u16)
+        });
+
+        unsafe {
+            // Plan to reload same config
+            DESCRIPTORS.21.transfer_config = self.raw.channel21.xfercfg.read().bits();
+            DESCRIPTORS.21.source_end_addr = (raw::ADC0::ptr() as u32) + 0x300;     // FIFOA offset
+            DESCRIPTORS.21.dest_end_addr = (recv_buf.as_mut_ptr() as u32) + (recv_buf.len() * 4 - 4) as u32;
+            // Point back to itself to loop & use circular buffer.
+            DESCRIPTORS.21.next = ((&DESCRIPTORS.21) as *const Descriptor) as u32;      
+        }
+
+        adc.de.write(|w| { 
+            w.fwmde0().set_bit() // Enable FIFO A dma
+        });  
+
+
+        adc.fctrl[0].modify(|_,w| unsafe {
+            w.fwmark().bits(2)  // when >2 samples in FIFO, dma request is issued.
+        });
+
+        // enable channel
+        self.raw.enableset0.write(|w| unsafe { w.bits(1<<21) });
+
+        // trigger
+        self.raw.channel21.xfercfg.modify(|_,w| { w.swtrig().set_bit() });
+    }
+}

--- a/src/peripherals/pmc.rs
+++ b/src/peripherals/pmc.rs
@@ -125,3 +125,4 @@ macro_rules! impl_power_control {
 // and on top of that USBFSD, USBFSHM, USBFSHS... to make this all logical.
 impl_power_control!(raw::USB0, pden_usbfsphy);
 impl_power_control!(raw::USBFSH, pden_usbfsphy);
+impl_power_control!(raw::ADC0, pden_auxbias);

--- a/src/peripherals/syscon.rs
+++ b/src/peripherals/syscon.rs
@@ -214,6 +214,7 @@ impl_clock_control!(raw::CTIMER1, timer1, ahbclkctrl1);
 impl_clock_control!(raw::CTIMER2, timer2, ahbclkctrl1);
 impl_clock_control!(raw::CTIMER3, timer3, ahbclkctrl2);
 impl_clock_control!(raw::CTIMER4, timer4, ahbclkctrl2);
+impl_clock_control!(raw::DMA0, dma0, ahbclkctrl0);
 impl_clock_control!(raw::FLASH, flash, ahbclkctrl0);
 impl_clock_control!(raw::FLEXCOMM0, fc0, ahbclkctrl1);
 impl_clock_control!(raw::FLEXCOMM1, fc1, ahbclkctrl1);

--- a/src/peripherals/syscon.rs
+++ b/src/peripherals/syscon.rs
@@ -209,6 +209,11 @@ macro_rules! impl_clock_control {
 }
 
 impl_clock_control!(raw::ADC0, adc, ahbclkctrl0);
+impl_clock_control!(raw::CTIMER0, timer0, ahbclkctrl1);
+impl_clock_control!(raw::CTIMER1, timer1, ahbclkctrl1);
+impl_clock_control!(raw::CTIMER2, timer2, ahbclkctrl1);
+impl_clock_control!(raw::CTIMER3, timer3, ahbclkctrl2);
+impl_clock_control!(raw::CTIMER4, timer4, ahbclkctrl2);
 impl_clock_control!(raw::FLASH, flash, ahbclkctrl0);
 impl_clock_control!(raw::FLEXCOMM0, fc0, ahbclkctrl1);
 impl_clock_control!(raw::FLEXCOMM1, fc1, ahbclkctrl1);
@@ -295,6 +300,11 @@ macro_rules! impl_reset_control {
 
 // to be completed
 impl_reset_control!(raw::CASPER, casper_rst, presetctrl2);
+impl_reset_control!(raw::CTIMER0, timer0_rst, presetctrl1);
+impl_reset_control!(raw::CTIMER1, timer1_rst, presetctrl1);
+impl_reset_control!(raw::CTIMER2, timer2_rst, presetctrl1);
+impl_reset_control!(raw::CTIMER3, timer3_rst, presetctrl2);
+impl_reset_control!(raw::CTIMER4, timer4_rst, presetctrl2);
 impl_reset_control!(raw::FLEXCOMM0, fc0_rst, presetctrl1);
 impl_reset_control!(raw::FLEXCOMM1, fc1_rst, presetctrl1);
 impl_reset_control!(raw::FLEXCOMM2, fc2_rst, presetctrl1);

--- a/src/time.rs
+++ b/src/time.rs
@@ -64,6 +64,39 @@ impl From<Megabaud> for Baud {
     }
 }
 
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub struct Seconds(pub u32);
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub struct MiliSeconds(pub u32);
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub struct MicroSeconds(pub u32);
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub struct NanoSeconds(pub u32);
+
+impl From<Seconds> for MiliSeconds{
+    fn from(s: Seconds) -> Self {
+        MiliSeconds(1_000 * s.0)
+    }
+}
+
+impl From<Seconds> for MicroSeconds{
+    fn from(s: Seconds) -> Self {
+        MicroSeconds(1_000_000 * s.0)
+    }
+}
+
+impl From<MiliSeconds> for MicroSeconds {
+    fn from(ms: MiliSeconds) -> Self {
+        MicroSeconds(1_000 * ms.0)
+    }
+}
+
+impl From<MicroSeconds> for NanoSeconds{
+    fn from(us: MicroSeconds) -> Self {
+        NanoSeconds(1_000 * us.0)
+    }
+}
+
 pub trait U32Ext {
     /// Wrap in `Hertz`
     fn hz(self) -> Hertz;
@@ -82,6 +115,18 @@ pub trait U32Ext {
 
     /// Wrap in `Megabaud`
     fn mbps(self) -> Megabaud;
+
+    /// Wrap in `Seconds`
+    fn s(self) -> Seconds;
+
+    /// Wrap in `MiliSeconds`
+    fn ms(self) -> MiliSeconds;
+
+    /// Wrap in `MicroSeconds`
+    fn us(self) -> MicroSeconds;
+
+    /// Wrap in `NanoSeconds`
+    fn ns(self) -> NanoSeconds;
 }
 
 impl U32Ext for u32 {
@@ -108,7 +153,24 @@ impl U32Ext for u32 {
     fn mbps(self) -> Megabaud {
         Megabaud(self)
     }
+
+    fn s(self) -> Seconds {
+        Seconds(self)
+    }
+
+    fn ms(self) -> MiliSeconds {
+        MiliSeconds(self)
+    }
+
+    fn us(self) -> MicroSeconds {
+        MicroSeconds(self)
+    }
+
+    fn ns(self) -> NanoSeconds {
+        NanoSeconds(self)
+    }
 }
+
 
 
 ////////////////////////////////////

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -57,5 +57,6 @@ pub mod reg_proxy {
 // maybe put in submodule?
 pub trait Gint: Deref<Target = crate::raw::gint0::RegisterBlock> {}
 
+pub mod buttons;
 pub mod flash;
 

--- a/src/traits/buttons.rs
+++ b/src/traits/buttons.rs
@@ -1,4 +1,4 @@
-use void::Void;
+use core::convert::Infallible;
 use nb;
 
 /// Which button is pressed
@@ -21,7 +21,7 @@ pub struct Buttons {
 pub use Button::*;
 
 /// A type alias for the result of waiting for a Button operation.
-pub type Result = nb::Result<Button, Void>;
+pub type Result = nb::Result<Button, Infallible>;
 
 pub trait ButtonPress {
 

--- a/src/traits/buttons.rs
+++ b/src/traits/buttons.rs
@@ -1,0 +1,54 @@
+use void::Void;
+use nb;
+
+/// Which button is pressed
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Button {
+    ButtonTop,
+    ButtonBot,
+    ButtonSides,
+    ButtonMid,
+    ButtonAny,
+    ButtonNone,
+}
+
+pub struct Buttons {
+    pub top: bool,
+    pub bot: bool,
+    pub mid: bool,
+}
+
+pub use Button::*;
+
+/// A type alias for the result of waiting for a Button operation.
+pub type Result = nb::Result<Button, Void>;
+
+pub trait ButtonPress {
+
+    /// Is the specific button currently activated
+    fn is_pressed(&self, but: Button) -> bool;
+
+    /// Is the specific button currently released
+    fn is_released(&self, but: Button) -> bool;
+
+    /// Return the current state (pressed / released) of the three buttons.
+    fn get_status(&self) -> Buttons;
+
+}
+
+pub trait ButtonEdge{
+    /// Non-blockingly wait for the button to be pressed.
+    /// This is edge sensitive, meaning it will not complete successfully more than once
+    /// per actual button press.
+    /// Use block!(...) macro to actually block.
+    fn wait_for_press(&self, but: Button) -> Result;
+
+    /// Same as for wait_for_press, but waits for the release of the button.
+    fn wait_for_release(&self, but: Button) -> Result;
+
+    /// See wait_for_press
+    fn wait_for_any_press(&self, ) -> Result;
+
+    /// See wait_for_release
+    fn wait_for_any_release(&self, ) -> Result;
+}

--- a/src/typestates.rs
+++ b/src/typestates.rs
@@ -76,6 +76,10 @@ pub struct ClocksSupportUsbfsToken {pub(crate) __: ()}
 /// a frozen Clocks (clock-tree configuration)
 pub struct ClocksSupportUtickToken {pub(crate) __: ()}
 
+/// Application can only obtain this token from
+/// a frozen Clocks (clock-tree configuration)
+pub struct ClocksSupportTouchToken{pub(crate) __: ()}
+
 pub mod flash_state {
 }
 

--- a/src/typestates/pin.rs
+++ b/src/typestates/pin.rs
@@ -59,7 +59,14 @@ pub mod state {
         pub(crate) _direction: D,
     }
 
+    pub struct Analog<D: Direction> {
+        pub channel: u8,
+        pub(crate) dirclr: RegClusterProxy<raw::gpio::DIRCLR>,
+        pub(crate) _direction: D,
+    }
+
     impl<D> PinState for Gpio<D> where D: Direction {}
+    impl<D> PinState for Analog<D> where D: Direction {}
 
     pub struct Special<F: Function> {
         pub(crate) _function: F,
@@ -67,6 +74,7 @@ pub mod state {
 
     impl<F> PinState for Special<F> where F: Function {}
 }
+
 pub mod gpio {
     pub mod direction {
         /// Implemented by types that indicate GPIO pin direction
@@ -80,6 +88,12 @@ pub mod gpio {
 
         pub struct Output;
         impl Direction for Output {}
+
+        pub struct AnalogInput;
+        impl Direction for AnalogInput{}
+
+        pub struct AnalogOutput;
+        impl Direction for AnalogOutput {}
 
         pub trait NotInput: Direction {}
         impl NotInput for Unknown {}

--- a/src/typestates/pin/function.rs
+++ b/src/typestates/pin/function.rs
@@ -10,6 +10,51 @@ impl Function for SWDIO {}
 pub struct USB0_VBUS;
 impl Function for USB0_VBUS {}
 
+pub struct CT0MAT3 {}
+impl Function for CT0MAT3 {}
+pub struct CT1MAT3 {}
+impl Function for CT1MAT3 {}
+pub struct CT2MAT3 {}
+impl Function for CT2MAT3 {}
+pub struct CT3MAT3 {}
+impl Function for CT3MAT3 {}
+pub struct CT4MAT3 {}
+impl Function for CT4MAT3 {}
+
+pub struct CT0MAT2 {}
+impl Function for CT0MAT2 {}
+pub struct CT1MAT2 {}
+impl Function for CT1MAT2 {}
+pub struct CT2MAT2 {}
+impl Function for CT2MAT2 {}
+pub struct CT3MAT2 {}
+impl Function for CT3MAT2 {}
+pub struct CT4MAT2 {}
+impl Function for CT4MAT2 {}
+
+pub struct CT0MAT1 {}
+impl Function for CT0MAT1 {}
+pub struct CT1MAT1 {}
+impl Function for CT1MAT1 {}
+pub struct CT2MAT1 {}
+impl Function for CT2MAT1 {}
+pub struct CT3MAT1 {}
+impl Function for CT3MAT1 {}
+pub struct CT4MAT1 {}
+impl Function for CT4MAT1 {}
+
+pub struct CT0MAT0 {}
+impl Function for CT0MAT0 {}
+pub struct CT1MAT0 {}
+impl Function for CT1MAT0 {}
+pub struct CT2MAT0 {}
+impl Function for CT2MAT0 {}
+pub struct CT3MAT0 {}
+impl Function for CT3MAT0 {}
+pub struct CT4MAT0 {}
+impl Function for CT4MAT0 {}
+
+
 // these are generated with `generate-flexcomm-pin-driver.py`
 pub struct FC0_CTS_SDA_SSEL0;
 impl Function for FC0_CTS_SDA_SSEL0 {}

--- a/src/typestates/pin/function.rs
+++ b/src/typestates/pin/function.rs
@@ -10,50 +10,8 @@ impl Function for SWDIO {}
 pub struct USB0_VBUS;
 impl Function for USB0_VBUS {}
 
-pub struct CT0MAT3 {}
-impl Function for CT0MAT3 {}
-pub struct CT1MAT3 {}
-impl Function for CT1MAT3 {}
-pub struct CT2MAT3 {}
-impl Function for CT2MAT3 {}
-pub struct CT3MAT3 {}
-impl Function for CT3MAT3 {}
-pub struct CT4MAT3 {}
-impl Function for CT4MAT3 {}
-
-pub struct CT0MAT2 {}
-impl Function for CT0MAT2 {}
-pub struct CT1MAT2 {}
-impl Function for CT1MAT2 {}
-pub struct CT2MAT2 {}
-impl Function for CT2MAT2 {}
-pub struct CT3MAT2 {}
-impl Function for CT3MAT2 {}
-pub struct CT4MAT2 {}
-impl Function for CT4MAT2 {}
-
-pub struct CT0MAT1 {}
-impl Function for CT0MAT1 {}
-pub struct CT1MAT1 {}
-impl Function for CT1MAT1 {}
-pub struct CT2MAT1 {}
-impl Function for CT2MAT1 {}
-pub struct CT3MAT1 {}
-impl Function for CT3MAT1 {}
-pub struct CT4MAT1 {}
-impl Function for CT4MAT1 {}
-
-pub struct CT0MAT0 {}
-impl Function for CT0MAT0 {}
-pub struct CT1MAT0 {}
-impl Function for CT1MAT0 {}
-pub struct CT2MAT0 {}
-impl Function for CT2MAT0 {}
-pub struct CT3MAT0 {}
-impl Function for CT3MAT0 {}
-pub struct CT4MAT0 {}
-impl Function for CT4MAT0 {}
-
+pub struct CTIMER_MAT{}
+impl Function for CTIMER_MAT{}
 
 // these are generated with `generate-flexcomm-pin-driver.py`
 pub struct FC0_CTS_SDA_SSEL0;


### PR DESCRIPTION
This adds capacitive touch sensing driver for LPC55 which implements a suggested button trait for an authenticator.

Added in this request:
* ADC peripheral
* Ctimer peripherals + Timer driver
* DMA peripheral
* Analog type for pins
* Buttons trait
* TouchSensor driver (implements Buttons)

The touch sensing uses a CTIMER MAT output to drive charging/discharging the electrodes, which also directly starts ADC conversions that alternate between 3 ADC channels (3 buttons).  The ADC FIFO triggers DMA to an internal circular buffer that the touch driver uses to figure out a button's state or if there's an edge.  No interrupt handlers needed.

```rust
    loop {

        let p = touch_sensor.wait_for_any_press();
        if  p.is_ok() {
            heprintln!("press {:?}", p.unwrap()).unwrap();
        }

        let p = touch_sensor.wait_for_any_release();
        if  p.is_ok() {
            heprintln!("release {:?}", p.unwrap()).unwrap();
        }

    }
```
->
```
press ButtonMid
release ButtonMid
press ButtonBot
release ButtonBot
```

Depends on https://github.com/nickray/lpc55-pac/pull/3#pullrequestreview-343570271 being merged.


