### PR TITLE
enable 1mhz clock for ctimer

### DIFF
--- a/examples/ctimer.rs
+++ b/examples/ctimer.rs
@@ -28,12 +28,12 @@ fn main() -> ! {
     // Get pointer to all device peripherals.
     let mut hal = hal::new();
 
-    let _clocks = hal::ClockRequirements::default()
+    let clocks = hal::ClockRequirements::default()
         .system_frequency(12.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
 
-    let ctimer = hal.ctimer.1.enabled(&mut hal.syscon);
+    let ctimer = hal.ctimer.1.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap());
     let mut cdriver = Timer::new(ctimer);
 
     heprintln!("looping 1 Hz").unwrap();

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
 
     let mut hal = hal::new();
 
-    let _clocks = hal::ClockRequirements::default()
+    let clocks = hal::ClockRequirements::default()
         .system_frequency(96.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
@@ -54,10 +54,10 @@ fn main() -> ! {
     let mut iocon = hal.iocon.enabled(&mut hal.syscon);
     let pins = Pins::take().unwrap();
 
-    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon));
+    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
 
     // Xpresso LED (they used same channel for two pins)
-    let mut pwm = Pwm::new(hal.ctimer.2.enabled(&mut hal.syscon));
+    let mut pwm = Pwm::new(hal.ctimer.2.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
     let blue = pins.pio1_6.into_match_output(&mut iocon);
     let green = pins.pio1_7.into_match_output(&mut iocon);
     let red = pins.pio1_4.into_match_output(&mut iocon);

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -51,7 +51,7 @@ fn main() -> ! {
         .configure(&mut anactrl, &mut pmc, &mut syscon)
         .unwrap();
 
-    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut syscon));
+    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()));
 
     // Can use compile to use either the "HighSpeed" or "FullSpeed" USB peripheral.
     // Default is full speed.

--- a/examples/usb_test_class.rs
+++ b/examples/usb_test_class.rs
@@ -38,7 +38,7 @@ fn main() -> ! {
         .expect("Clock configuration failed");
 
 
-    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut syscon));
+    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()));
 
     // Can use compile to use either the "HighSpeed" or "FullSpeed" USB peripheral.
     // Default is full speed.

--- a/src/drivers/clocks.rs
+++ b/src/drivers/clocks.rs
@@ -15,6 +15,7 @@ use crate::typestates::{
     ClocksSupportUsbhsToken,
     ClocksSupportUtickToken,
     ClocksSupportTouchToken,
+    ClocksSupport1MhzFroToken,
 };
 use crate::{
     peripherals::{
@@ -84,6 +85,10 @@ impl Clocks {
         Some(ClocksSupportUtickToken{__: ()})
     }
 
+    pub fn support_1mhz_fro_token(&self) -> Option<ClocksSupport1MhzFroToken> {
+        Some(ClocksSupport1MhzFroToken{__: ()})
+    }
+
     pub fn support_touch_token(&self) -> Option<ClocksSupportTouchToken> {
         if self.system_frequency.0 >= 96 {
             Some(ClocksSupportTouchToken{__: ()})
@@ -91,7 +96,7 @@ impl Clocks {
             None
         }
     }
-    
+
 }
 
 /// Output of Pll is: M/(2NP) times input
@@ -208,12 +213,12 @@ impl ClockRequirements {
             return Err(ClocksError::AlreadyConfigured);
         }
 
-        let default_freq = if self.support_usbfs { 
-            MIN_USBFS_FREQ 
+        let default_freq = if self.support_usbfs {
+            MIN_USBFS_FREQ
         } else if self.support_usbhs {
             MIN_USBHS_FREQ
-        } else { 
-            DEFAULT_FREQ 
+        } else {
+            DEFAULT_FREQ
         };
 
         let freq: Megahertz = self.system_frequency.unwrap_or(default_freq);

--- a/src/peripherals/ctimer.rs
+++ b/src/peripherals/ctimer.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     typestates::{
         init_state,
+        ClocksSupport1MhzFroToken,
     },
 };
 
@@ -30,12 +31,12 @@ macro_rules! ctimer {
         fn deref(&self) -> &Self::Target {
             &self.raw
         }
-    }   
+    }
     impl Ctimer<init_state::Enabled> for $c_hal<init_state::Enabled> {}
-    
+
 
     impl<State> $c_hal<State> {
-        pub fn enabled(mut self, syscon: &mut Syscon, ) -> $c_hal <init_state::Enabled> {
+        pub fn enabled(mut self, syscon: &mut Syscon, _token: ClocksSupport1MhzFroToken) -> $c_hal <init_state::Enabled> {
             syscon.enable_clock(&mut self.raw);
             syscon.raw.$register().write(|w| { w.sel().$clock_input() } );
             syscon.reset(&mut self.raw);

--- a/src/typestates.rs
+++ b/src/typestates.rs
@@ -100,6 +100,10 @@ pub struct ClocksSupportUtickToken {pub(crate) __: ()}
 /// a frozen Clocks (clock-tree configuration)
 pub struct ClocksSupportTouchToken{pub(crate) __: ()}
 
+/// Application can only obtain this token from
+/// a frozen Clocks (clock-tree configuration)
+pub struct ClocksSupport1MhzFroToken{pub(crate) __: ()}
+
 pub mod flash_state {
 }
 


### PR DESCRIPTION
The ctimer peripheral drivers (and PWM driver) rely on the 1MHz oscillator as an input but they didn't enable it.