### PR TITLE
Empirically, USB FS can use 5 non-control endpoints too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,8 @@ littlefs = ["littlefs2"]
 logging = ["cortex-m-funnel", "ufmt"]
 rt = ["lpc55-pac/rt"]
 rtfm-peripherals = ["cortex-m-rtfm"]
-highspeed-usb = []
+# no longer a HAL feature, just for the usb examples
+highspeed-usb-example = []
 # # Boards
 # lpcxpresso55s69 = []
 # solo = []

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -41,6 +41,7 @@ fn main() -> ! {
         .system_frequency(96.mhz())
         .configure(&mut hal.anactrl, &mut hal.pmc, &mut hal.syscon)
         .unwrap();
+    let fro_token = clocks.support_1mhz_fro_token().unwrap();
 
     let touch_token = clocks.support_touch_token().unwrap();
 
@@ -67,7 +68,7 @@ fn main() -> ! {
         .into_gpio_pin(&mut iocon, &mut gpio)
         .into_output(Level::High);
 
-    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
+    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon, fro_token));
 
     let button_pins = ButtonPins(but1,but2,but3);
 

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
     // Can use compile to use either the "HighSpeed" or "FullSpeed" USB peripheral.
     // Default is full speed.
-    #[cfg(feature = "highspeed-usb")]
+    #[cfg(feature = "highspeed-usb-example")]
     let usb_peripheral = hal.usbhs.enabled_as_device(
         &mut anactrl,
         &mut pmc,
@@ -64,7 +64,7 @@ fn main() -> ! {
                         .unwrap()
     );
 
-    #[cfg(not(feature = "highspeed-usb"))]
+    #[cfg(not(feature = "highspeed-usb-example"))]
     let usb_peripheral = hal.usbfs.enabled_as_device(
         &mut anactrl,
         &mut pmc,

--- a/examples/usb_test_class.rs
+++ b/examples/usb_test_class.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
 
     // Can use compile to use either the "HighSpeed" or "FullSpeed" USB peripheral.
     // Default is full speed.
-    #[cfg(feature = "highspeed-usb")]
+    #[cfg(feature = "highspeed-usb-example")]
     let usb_peripheral = hal.usbhs.enabled_as_device(
         &mut anactrl,
         &mut pmc,
@@ -51,7 +51,7 @@ fn main() -> ! {
                         .unwrap()
     );
 
-    #[cfg(not(feature = "highspeed-usb"))]
+    #[cfg(not(feature = "highspeed-usb-example"))]
     let usb_peripheral = hal.usbfs.enabled_as_device(
         &mut anactrl,
         &mut pmc,

--- a/src/drivers/usbd.rs
+++ b/src/drivers/usbd.rs
@@ -71,6 +71,9 @@ impl<P> Usb0VbusPin for Pin<P, pin::state::Special<pin::function::USB0_VBUS>> wh
 /// After the bus is enabled, in practice most access won't mutate the object itself
 /// but only endpoint-specific registers and buffers, the access to which is mostly
 /// arbitrated by endpoint handles.
+///
+/// Warning: Currently, `UsbBus` uses the same `USB1_SRAM` memory region for both FS and HS
+/// peripherals, so it's not possible to use both peripherals at the same time with this driver.
 pub struct UsbBus<USB>
 where
     USB: Usb<init_state::Enabled> + Send,

--- a/src/drivers/usbd/constants.rs
+++ b/src/drivers/usbd/constants.rs
@@ -1,16 +1,10 @@
 pub type UsbAccessType = u8; // note this is just a type definition, we depend on its size
 
-// TODO: Ideally, user could use both FS and HS peripherals.
-// Then the Cargo feature could go away as well.
-// For this, would need to move NUM_ENDPOINTS from global constants
-// to associated constant (of traits::usb::Usb),
-// but this does not currently work.
 /// Number of logical endpoints, including control
-/// Default is full speed (5 endpoints).
-#[cfg(feature = "highspeed-usb")]
+///
+/// Despite the UM claiming that USB FS has 1 + 4 and USB HS has 1 + 5,
+/// even the FS supports 1 + 5 endpoints.
 pub const NUM_ENDPOINTS: usize = 1 + 5;
-#[cfg(not(feature = "highspeed-usb"))]
-pub const NUM_ENDPOINTS: usize = 1 + 4;
 pub const BYTES_PER_EP_REGISTER: usize = 4*4;
 
 pub const USB1_SRAM_ADDR: usize = 0x4010_0000;

--- a/src/drivers/usbd/endpoint_list.rs
+++ b/src/drivers/usbd/endpoint_list.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 
 static mut ENDPOINT_LIST_ATTACHED: bool = false;
 
-pub const USB1_SRAM_ADDR: u32 = 0x4010_0000;
+pub use super::constants::USB1_SRAM_ADDR;
 pub const DA_BUF_ADDR: u32 = 0x4000_0000;  // 4MB = increments of 0x40_0000
 /// There are only two possible choices here:
 /// - 0x100 to use the USB1_SRAM

--- a/src/peripherals/usbfs.rs
+++ b/src/peripherals/usbfs.rs
@@ -13,7 +13,6 @@ use crate::typestates::{
     ClocksSupportUsbfsToken,
 };
 
-#[cfg(not(feature = "highspeed-usb"))]
 use crate::traits::usb::{
     Usb,
     UsbSpeed,
@@ -41,7 +40,6 @@ impl Deref for EnabledUsbfsDevice {
 
 unsafe impl Sync for EnabledUsbfsDevice {}
 
-#[cfg(not(feature = "highspeed-usb"))]
 impl Usb<init_state::Enabled> for EnabledUsbfsDevice {
     const SPEED: UsbSpeed = UsbSpeed::FullSpeed;
     // const NUM_ENDPOINTS: usize = 1 + 5;

--- a/src/peripherals/usbhs.rs
+++ b/src/peripherals/usbhs.rs
@@ -16,7 +16,6 @@ use crate::typestates::{
     ClocksSupportUsbhsToken,
 };
 
-#[cfg(feature = "highspeed-usb")]
 use crate::traits::usb::{
     Usb,
     UsbSpeed,
@@ -45,7 +44,6 @@ impl Deref for EnabledUsbhsDevice {
 
 unsafe impl Sync for EnabledUsbhsDevice {}
 
-#[cfg(feature = "highspeed-usb")]
 impl Usb<init_state::Enabled> for EnabledUsbhsDevice {
     const SPEED: UsbSpeed = UsbSpeed::HighSpeed;
     // const NUM_ENDPOINTS: usize = 1 + 5;

--- a/src/typestates.rs
+++ b/src/typestates.rs
@@ -80,28 +80,34 @@ pub mod usbhs_mode {
 
 /// Application can only obtain this token from
 /// a frozen Clocks (clock-tree configuration)
+#[derive(Copy, Clone)]
 pub struct ClocksSupportFlexcommToken {pub(crate) __: ()}
 
 /// Application can only obtain this token from
 /// a frozen Clocks (clock-tree configuration) for
 /// which USB clocks have been configured properly.
+#[derive(Copy, Clone)]
 pub struct ClocksSupportUsbfsToken {pub(crate) __: ()}
 
 /// Application can only obtain this token from
 /// a frozen Clocks (clock-tree configuration) for
 /// which USB clocks have been configured properly.
+#[derive(Copy, Clone)]
 pub struct ClocksSupportUsbhsToken {pub(crate) __: ()}
 
 /// Application can only obtain this token from
 /// a frozen Clocks (clock-tree configuration)
+#[derive(Copy, Clone)]
 pub struct ClocksSupportUtickToken {pub(crate) __: ()}
 
 /// Application can only obtain this token from
 /// a frozen Clocks (clock-tree configuration)
+#[derive(Copy, Clone)]
 pub struct ClocksSupportTouchToken{pub(crate) __: ()}
 
 /// Application can only obtain this token from
 /// a frozen Clocks (clock-tree configuration)
+#[derive(Copy, Clone)]
 pub struct ClocksSupport1MhzFroToken{pub(crate) __: ()}
 
 pub mod flash_state {


### PR DESCRIPTION
The world does not explode if I add a CCID interrupt endpoint with this change.