### PR TITLE
Improve PWM, ADC, and Clock drivers

### DIFF
--- a/examples/measure_frequency.rs
+++ b/examples/measure_frequency.rs
@@ -39,12 +39,12 @@ fn main() -> ! {
     let mut pmc = hal.pmc;
     let mut syscon = hal.syscon;
 
-    let _clocks = hal::ClockRequirements::default()
+    let clocks = hal::ClockRequirements::default()
         .system_frequency(150.mhz())
         .configure(&mut anactrl, &mut pmc, &mut syscon)
         .unwrap();
 
-    let mut timer = Timer::new(hal.ctimer.0.enabled(&mut syscon));
+    let mut timer = Timer::new(hal.ctimer.0.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()));
 
     hal::enable_cycle_counter();
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -57,16 +57,16 @@ fn main() -> ! {
     let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
 
     // Xpresso LED (they used same channel for two pins)
-    let mut pwm = Pwm::new(hal.ctimer.2.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
-    let blue = pins.pio1_6.into_match_output(&mut iocon);
-    let green = pins.pio1_7.into_match_output(&mut iocon);
-    let red = pins.pio1_4.into_match_output(&mut iocon);
+    // let mut pwm = Pwm::new(hal.ctimer.2.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
+    // let blue = pins.pio1_6.into_match_output(&mut iocon);
+    // let green = pins.pio1_7.into_match_output(&mut iocon);
+    // let red = pins.pio1_4.into_match_output(&mut iocon);
 
     // Bee LED
-    // let mut pwm = Pwm::new(hal.ctimer.3.enabled(&mut hal.syscon));
-    // let red = pins.pio1_21.into_ctimer3_mat2(&mut iocon);
-    // let green = pins.pio0_5.into_ctimer3_mat0(&mut iocon);
-    // let blue = pins.pio1_19.into_ctimer3_mat1(&mut iocon);
+    let mut pwm = Pwm::new(hal.ctimer.3.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
+    let red = pins.pio1_21.into_match_output(&mut iocon);
+    let green = pins.pio0_5.into_match_output(&mut iocon);
+    let blue = pins.pio1_19.into_match_output(&mut iocon);
 
     // 0 = 100% high voltage / off
     // 128 = 50% high/low voltage
@@ -83,6 +83,7 @@ fn main() -> ! {
     let mut duties = [0f32, 30f32, 60f32];
     let increments = [0.3f32, 0.2f32, 0.1f32];
 
+    pwm.scale_max_duty_by(10);
 
     loop {
 
@@ -97,17 +98,17 @@ fn main() -> ! {
         }
 
         for i in 0..3 {
-            let duty = (sin(duties[i] * 3.14159265f32/180f32) * 255f32) as u8;
+            let duty = (sin(duties[i] * 3.14159265f32/180f32) * 255f32) as u16;
             match i {
                 0 => {
                     // need to tune down red some
-                    pwm.set_duty(red.get_channel(), duty/10);
+                    pwm.set_duty(red.get_channel(), duty as u16);
                 }
                 1 => {
-                    pwm.set_duty(green.get_channel(), duty/5);
+                    pwm.set_duty(green.get_channel(), duty*2);
                 }
                 2 => {
-                    pwm.set_duty(blue.get_channel(), duty/5);
+                    pwm.set_duty(blue.get_channel(), duty*2);
                 }
                 _ => {}
             }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -67,14 +67,14 @@ fn main() -> ! {
         .into_gpio_pin(&mut iocon, &mut gpio)
         .into_output(Level::High);
 
-    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon));
+    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap()));
 
     let button_pins = ButtonPins(but1,but2,but3);
 
     let adc = hal::Adc::from(hal.adc).enabled(&mut hal.pmc, &mut hal.syscon);
 
-    let touch_timer = hal.ctimer.1.enabled(&mut hal.syscon);
-    let touch_sync_timer = hal.ctimer.2.enabled(&mut hal.syscon);
+    let touch_timer = hal.ctimer.1.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap());
+    let touch_sync_timer = hal.ctimer.2.enabled(&mut hal.syscon, clocks.support_1mhz_fro_token().unwrap());
     let charge_pin = pins.pio1_16.into_match_output(&mut iocon);
 
     let mut dma = hal::Dma::from(hal.dma).enabled(&mut hal.syscon);

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -47,7 +47,6 @@ fn main() -> ! {
         // .system_frequency(24.mhz())
         // .system_frequency(72.mhz())
         .system_frequency(96.mhz())
-        .support_usbhs()
         .configure(&mut anactrl, &mut pmc, &mut syscon)
         .unwrap();
 

--- a/examples/usb_test_class.rs
+++ b/examples/usb_test_class.rs
@@ -33,7 +33,6 @@ fn main() -> ! {
 
     let clocks = hal::ClockRequirements::default()
         .system_frequency(96.mhz())
-        .support_usbhs()
         .configure(&mut anactrl, &mut pmc, &mut syscon)
         .expect("Clock configuration failed");
 

--- a/src/drivers/pwm.rs
+++ b/src/drivers/pwm.rs
@@ -21,6 +21,58 @@ impl <TIMER> Pwm <TIMER>
 where TIMER: Ctimer<init_state::Enabled> {
 
     pub fn new(timer: TIMER) -> Self{
+
+        // Match should reset and stop timer, and generate interrupt.
+        timer.mcr.modify(|_,w| {
+            w
+            .mr3i().set_bit()
+            .mr3r().set_bit()
+            .mr3s().clear_bit()
+        });
+
+        timer.pwmc.modify(|_,w|
+            w.
+            pwmen3().clear_bit()
+        );
+
+        // Set max duty cycle to 3rd match register (256 timer counts per pwm period)
+        timer.mr[3].write(|w| unsafe { w.bits(0xff) });
+
+        timer.mr[0].write(|w| unsafe{ w.bits(0x0) });
+        timer.mr[1].write(|w| unsafe{ w.bits(0x0) });
+        timer.mr[2].write(|w| unsafe{ w.bits(0x0) });
+
+        timer.mcr.modify(|_,w| {
+            w
+            .mr0i().set_bit()
+            .mr0r().clear_bit()
+            .mr0s().clear_bit()
+
+            .mr1i().set_bit()
+            .mr1r().clear_bit()
+            .mr1s().clear_bit()
+
+            .mr2i().set_bit()
+            .mr2r().clear_bit()
+            .mr2s().clear_bit()
+        });
+        timer.pwmc.modify(|_,w|
+            w
+            .pwmen0().set_bit()
+            .pwmen1().set_bit()
+            .pwmen2().set_bit()
+        );
+
+        // No divsion necessary (1MHz / 256 ~= 4kHz at LED)
+        timer.pr.write(|w| unsafe {w.bits(0)});
+
+        // Start timer
+        timer.tcr.write(|w| {
+            w
+            .crst().clear_bit()
+            .cen().set_bit()
+        });
+
         Self {
             timer: timer,
         }
@@ -28,6 +80,11 @@ where TIMER: Ctimer<init_state::Enabled> {
 
     pub fn release(self) -> TIMER {
         self.timer
+    }
+
+    /// Increase maximum value for the duty cycle.
+    pub fn scale_max_duty_by(&mut self,duty:u32) {
+        self.timer.mr[3].write(|w| unsafe { w.bits(0xff* duty) });
     }
 
 }
@@ -38,75 +95,17 @@ where TIMER: Ctimer<init_state::Enabled>
 {
     type Channel = u8;
     type Time = MicroSeconds;
-    type Duty = u8;
+    type Duty = u16;
 
     fn enable(&mut self, channel: Self::Channel) {
-        // Match should reset and stop timer, and generate interrupt.
-        self.timer.mcr.modify(|_,w| {
-            w
-            .mr3i().set_bit()
-            .mr3r().set_bit()
-            .mr3s().clear_bit()
-        });
-
-        self.timer.pwmc.modify(|_,w|
-            w.
-            pwmen3().clear_bit()
-        );
-
         match channel {
-            0 => {
-                self.timer.mcr.modify(|_,w| {
-                    w
-                    .mr0i().set_bit()
-                    .mr0r().clear_bit()
-                    .mr0s().clear_bit()
-                });
-                self.timer.pwmc.modify(|_,w|
-                    w.
-                    pwmen0().set_bit()
-                );
-            }
-            1 => {
-                self.timer.mcr.modify(|_,w| {
-                    w
-                    .mr1i().set_bit()
-                    .mr1r().clear_bit()
-                    .mr1s().clear_bit()
-                });
-                self.timer.pwmc.modify(|_,w|
-                    w.
-                    pwmen1().set_bit()
-                );
-            }
-            2 => {
-                self.timer.mcr.modify(|_,w| {
-                    w
-                    .mr2i().set_bit()
-                    .mr2r().clear_bit()
-                    .mr2s().clear_bit()
-                });
-                self.timer.pwmc.modify(|_,w|
-                    w.
-                    pwmen2().set_bit()
-                );
+            0|1|2 => {
+
             }
             _ => {
                 panic!("Cannot use channel outside 0-2 for PWM.");
             }
         }
-
-        // Set max duty cycle to 3rd match register (256 timer counts per pwm period)
-        self.timer.mr[3].write(|w| unsafe { w.bits(0xff) });
-
-        // No divsion necessary (1MHz / 256 ~= 4kHz at LED)
-        self.timer.pr.write(|w| unsafe {w.bits(0)});
-
-        // Start timer
-        self.timer.tcr.write(|w| {
-            w.crst().clear_bit()
-            .cen().set_bit()
-        });
     }
 
     fn disable(&mut self, channel: Self::Channel) {
@@ -154,7 +153,7 @@ where TIMER: Ctimer<init_state::Enabled>
     }
 
     fn get_period(&self) -> Self::Time {
-        MicroSeconds(1_000_000 / 256)
+        MicroSeconds(1_000_000 / self.get_max_duty() as u32)
     }
 
     fn set_period<P>(&mut self, _period: P)
@@ -165,11 +164,11 @@ where TIMER: Ctimer<init_state::Enabled>
     }
 
     fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
-        self.timer.mr[channel as usize].read().bits() as u8
+        self.timer.mr[channel as usize].read().bits() as Self::Duty
     }
 
     fn get_max_duty(&self) -> Self::Duty {
-        255
+        self.timer.mr[3].read().bits() as Self::Duty
     }
 
     fn set_duty(&mut self, channel: Self::Channel, duty: Self::Duty) {

--- a/src/drivers/timer.rs
+++ b/src/drivers/timer.rs
@@ -53,17 +53,17 @@ where TIMER: Ctimer<init_state::Enabled> {
 }
 
 
-impl<TIMER> timer::CountDown for Timer<TIMER> 
+impl<TIMER> timer::CountDown for Timer<TIMER>
 where TIMER: Ctimer<init_state::Enabled>
 {
     type Time = TimeUnits;
 
-    fn start<T>(&mut self, count: T) 
+    fn start<T>(&mut self, count: T)
     where T: Into<Self::Time>
     {
         // Match should reset and stop timer, and generate interrupt.
         self.timer.mcr.modify(|_,w| {
-            w.mr0i().set_bit() 
+            w.mr0i().set_bit()
             .mr0r().set_bit()
             .mr0s().set_bit()
         } );
@@ -106,6 +106,7 @@ where TIMER: Ctimer<init_state::Enabled>
             w.crst().set_bit()
             .cen().clear_bit()
         });
+        self.timer.ir.write(|w| {w.mr0int().set_bit()});
         Ok(())
     }
 }


### PR DESCRIPTION
Some minor improvements to PWM and ADC.  For PWM, needed an easy way to scale the duty cycle range, which allows better RGB LED normalizing.

E.g. this could be done to make scale an RGB LED while not sacrificing resolution: 

```rust
// red 16x dimmer, green 2x dimmer, and blue 1x dimmer.
pwm.scale_max_duty_by(16);
// ...

pwm.set_duty(RED, intensity)
pwm.set_duty(GREEN, intensity * 8)
pwm.set_duty(BLUE, intensity * 16)
```

For the clock driver, I refactored and added an `unsafe` method to change the clock rate after it's already been configured.  I also deleted the peripheral related methods on `ClockRequirements`, since I think the tokens already provide a good safety measure against invalid clock configurations, but I can add back if you think they should stay.

```rust
// initial config
let mut clocks = hal::ClockRequirements::default()
    .system_frequency(96.mhz())
    .configure(&mut anactrl, &mut pmc, &mut syscon)
    .expect("Clock configuration failed");

// ...
clocks = unsafe { hal::ClockRequirements::default()
    .system_frequency(12.mhz())
    .reconfigure(clocks, &mut pmc, &mut syscon) };
```