### PR TITLE
Add rtc peripheral

### DIFF
--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -1,0 +1,53 @@
+#![no_main]
+#![no_std]
+/// Simple demo of the real time clock peripheral.
+
+extern crate panic_semihosting;  // 4004 bytes
+// extern crate panic_halt; // 672 bytes
+
+use cortex_m_semihosting::{heprintln};
+use cortex_m_rt::entry;
+
+use lpc55_hal as hal;
+use hal::{
+    prelude::*,
+};
+
+pub fn delay_cycles(delay: u64) {
+    let current = hal::get_cycle_count() as u64;
+    let mut target = current + delay;
+    if target > 0xFFFF_FFFF {
+        // wait for wraparound
+        target -= 0xFFFF_FFFF;
+        while target < hal::get_cycle_count() as u64 { continue; }
+    }
+    while target > hal::get_cycle_count() as u64 { continue; }
+}
+
+#[entry]
+fn main() -> ! {
+    let hal = hal::new();
+
+    let mut anactrl = hal.anactrl;
+    let mut pmc = hal.pmc;
+    let mut syscon = hal.syscon;
+
+    let clocks = hal::ClockRequirements::default()
+        .system_frequency(96.mhz())
+        .configure(&mut anactrl, &mut pmc, &mut syscon)
+        .unwrap();
+
+    let token_32k_fro = clocks.enable_32k_fro(&mut pmc);
+
+    let mut rtc = hal.rtc.enabled(&mut syscon, token_32k_fro);
+
+    hal::enable_cycle_counter();
+
+    // RTC is not reset by system reset, only by direct call or by power reboot.
+    rtc.reset();
+
+    loop {
+        delay_cycles(10_000_000);
+        heprintln!("{:?}", rtc.uptime()).ok();
+    }
+}

--- a/src/drivers/clocks.rs
+++ b/src/drivers/clocks.rs
@@ -16,6 +16,7 @@ use crate::typestates::{
     ClocksSupportUtickToken,
     ClocksSupportTouchToken,
     ClocksSupport1MhzFroToken,
+    ClocksSupport32KhzFroToken,
 };
 use crate::{
     peripherals::{
@@ -93,6 +94,12 @@ impl Clocks {
         } else {
             None
         }
+    }
+
+    pub fn enable_32k_fro(&self, pmc: &mut Pmc) -> ClocksSupport32KhzFroToken {
+        let mut token = ClocksSupport32KhzFroToken{__: ()};
+        pmc.power_on(&mut token);
+        token
     }
 
 }
@@ -359,7 +366,7 @@ impl ClockRequirements {
         // turn on 1mhz, 12mhz and 96mhz clocks
         anactrl.raw.fro192m_ctrl.modify(|_, w| w.ena_96mhzclk().enable());
         anactrl.raw.fro192m_ctrl.modify(|_, w| w.ena_12mhzclk().enable());
-        // TODO: not clear what the difference of these two is; eg. are both needed?
+
         syscon.raw.clock_ctrl.modify(|_, w| w
             .fro1mhz_clk_ena().enable()
             .fro1mhz_utick_ena().enable()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use peripherals::{
     pmc::Pmc,
     puf::Puf,
     rng::Rng,
+    rtc::Rtc,
     syscon::Syscon,
     usbfs::Usbfs,
     usbhs::Usbhs,
@@ -161,6 +162,9 @@ pub struct Peripherals {
     /// Random number generator
     pub rng: Rng,
 
+    /// Real time clock
+    pub rtc: Rtc,
+
     /// System configuration
     pub syscon: Syscon,
 
@@ -246,6 +250,7 @@ impl From<(raw::Peripherals, rtic::Peripherals)> for Peripherals {
             pint: Pint::from(p.PINT),
             pmc: Pmc::from(p.PMC),
             rng: Rng::from(p.RNG),
+            rtc: Rtc::from(p.RTC),
             syscon: Syscon::from(p.SYSCON),
             usbfs: Usbfs::from((p.USB0, p.USBFSH)),
             usbhs: Usbhs::from((p.USBPHY, p.USB1, p.USBHSH)),
@@ -306,6 +311,7 @@ impl From<(raw::Peripherals, raw::CorePeripherals)> for Peripherals {
             pint: Pint::from(p.PINT),
             pmc: Pmc::from(p.PMC),
             rng: Rng::from(p.RNG),
+            rtc: Rtc::from(p.RTC),
             syscon: Syscon::from(p.SYSCON),
             usbfs: Usbfs::from((p.USB0, p.USBFSH)),
             usbhs: Usbhs::from((p.USBPHY, p.USB1, p.USBHSH)),

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -35,6 +35,7 @@ pub mod pint;
 pub mod pmc;
 pub mod puf;
 pub mod rng;
+pub mod rtc;
 pub mod syscon;
 pub mod usbfs;
 pub mod usbhs;

--- a/src/peripherals/pmc.rs
+++ b/src/peripherals/pmc.rs
@@ -145,3 +145,4 @@ macro_rules! impl_power_control {
 impl_power_control!(raw::USB0, pden_usbfsphy);
 impl_power_control!(raw::USBPHY, pden_usbhsphy, pden_ldousbhs);
 impl_power_control!(raw::ADC0, pden_auxbias);
+impl_power_control!(crate::typestates::ClocksSupport32KhzFroToken, pden_fro32k);

--- a/src/peripherals/rtc.rs
+++ b/src/peripherals/rtc.rs
@@ -53,9 +53,11 @@ impl Rtc<init_state::Enabled> {
         self.raw.ctrl.write(|w| 
             w
             .rtc_en().set_bit()
-            .rtc_subsec_ena().set_bit()
             .swreset().clear_bit()
             .rtc_osc_pd().clear_bit()
         );
+        // After reset:
+        // This bit can only be set after the RTC_ENA bit (bit 7) is set by a previous write operation.
+        self.raw.ctrl.modify(|_,w| w.rtc_subsec_ena().set_bit() )
     }
 }

--- a/src/peripherals/rtc.rs
+++ b/src/peripherals/rtc.rs
@@ -1,0 +1,61 @@
+use core::time::Duration;
+use crate::{
+    raw,
+    peripherals::{
+        syscon::Syscon,
+    },
+    typestates::{
+        init_state,
+        ClocksSupport32KhzFroToken,
+    }
+};
+
+crate::wrap_stateful_peripheral!(Rtc, RTC);
+
+impl<State> Rtc<State> {
+    pub fn enabled(mut self, syscon: &mut Syscon, _token: ClocksSupport32KhzFroToken) -> Rtc<init_state::Enabled> {
+        syscon.enable_clock(&mut self.raw);
+        self.raw.ctrl.write(|w| 
+            w
+            .rtc_en().set_bit()
+            .rtc_subsec_ena().set_bit()
+            .swreset().clear_bit()
+            .rtc_osc_pd().clear_bit()
+        );
+        Rtc {
+            raw: self.raw,
+            _state: init_state::Enabled(()),
+        }
+    }
+
+    pub fn disabled(mut self, syscon: &mut Syscon) -> Rtc<init_state::Disabled> {
+        syscon.disable_clock(&mut self.raw);
+
+        Rtc {
+            raw: self.raw,
+            _state: init_state::Disabled,
+        }
+    }
+}
+
+impl Rtc<init_state::Enabled> {
+    pub fn uptime(&self) -> Duration {
+        let secs = self.raw.count.read().bits() as u64;
+        let ticks_32k = self.raw.subsec.read().bits() as u64;
+        Duration::from_secs(secs) + Duration::from_micros((ticks_32k * 61)/2)
+    }
+
+    pub fn reset(&mut self) {
+        self.raw.ctrl.write(|w| w.swreset().set_bit() );
+        while self.raw.ctrl.read().swreset().is_not_in_reset() {}
+        self.raw.ctrl.write(|w| w.swreset().clear_bit() );
+        while self.raw.ctrl.read().swreset().is_in_reset() {}
+        self.raw.ctrl.write(|w| 
+            w
+            .rtc_en().set_bit()
+            .rtc_subsec_ena().set_bit()
+            .swreset().clear_bit()
+            .rtc_osc_pd().clear_bit()
+        );
+    }
+}

--- a/src/peripherals/syscon.rs
+++ b/src/peripherals/syscon.rs
@@ -265,6 +265,7 @@ impl_clock_control!(raw::CASPER, casper, ahbclkctrl2);
 // impl_clock_control!(raw::GPIO_SEC, gpio_sec, ahbclkctrl2);
 impl_clock_control!(raw::PUF, puf, ahbclkctrl2);
 impl_clock_control!(raw::RNG, rng, ahbclkctrl2);
+impl_clock_control!(raw::RTC, rtc, ahbclkctrl0);
 
 // GPIO needs a separate implementation
 impl ClockControl for raw::GPIO {

--- a/src/typestates.rs
+++ b/src/typestates.rs
@@ -110,6 +110,11 @@ pub struct ClocksSupportTouchToken{pub(crate) __: ()}
 #[derive(Copy, Clone)]
 pub struct ClocksSupport1MhzFroToken{pub(crate) __: ()}
 
+/// Application can only obtain this token from
+/// a frozen Clocks (clock-tree configuration)
+#[derive(Copy, Clone)]
+pub struct ClocksSupport32KhzFroToken{pub(crate) __: ()}
+
 pub mod flash_state {
 }
 


### PR DESCRIPTION
Add RTC peripheral.  

```rust
let mut rtc = hal.rtc.enabled(&mut syscon, token_32k_fro);

loop {
    heprintln!("{:?}", rtc.uptime()).ok();
}
// 1s
// ..
// 2s
// ..
```

Right now this uses `core::time::Duration`, but let's do another PR replacing time related types with [embedded_time](https://docs.rs/embedded-time/0.10.0/embedded_time/)