### PR TITLE
add methods for managing important PFR regions

### DIFF
--- a/examples/pfr.rs
+++ b/examples/pfr.rs
@@ -1,0 +1,118 @@
+#![no_main]
+#![no_std]
+/// Simple example to measure the core clock frequency
+
+extern crate panic_semihosting;  // 4004 bytes
+// extern crate panic_halt; // 672 bytes
+
+use cortex_m_semihosting::{heprint,heprintln};
+use cortex_m_rt::entry;
+
+use lpc55_hal as hal;
+use hal::{
+    prelude::*,
+    peripherals::pfr::KeyType,
+};
+
+macro_rules! dump_hex {
+    ($array:expr, $length:expr ) => {
+
+        heprint!("{:?} = ", stringify!($array)).unwrap();
+        for i in 0..$length {
+            heprint!("{:02X}", $array[i]).unwrap();
+        }
+        heprintln!("").unwrap();
+
+    };
+}
+
+
+#[entry]
+fn main() -> ! {
+    let hal = hal::new();
+
+    let mut anactrl = hal.anactrl;
+    let mut pmc = hal.pmc;
+    let mut syscon = hal.syscon;
+
+
+    let clocks = hal::ClockRequirements::default()
+        .system_frequency(96.mhz())
+        .configure(&mut anactrl, &mut pmc, &mut syscon)
+        .unwrap();
+
+    let mut pfr = hal.pfr.enabled(&clocks).unwrap();
+    let mut cfpa = pfr.read_cfpa( ).unwrap();
+    heprintln!("CFPA:").ok();
+    heprintln!("header = {:08X}", cfpa.header).ok();
+    heprintln!("version = {:08X}", cfpa.version).ok();
+    heprintln!("secureVersion = {:08X}", cfpa.secure_fw_version).ok();
+    heprintln!("notSecureVersion = {:08X}", cfpa.ns_fw_version).ok();
+    
+    heprintln!("imageKeyRevoke = {:08X}", cfpa.image_key_revoke).ok();
+    heprintln!("rotkhRevoke = {:08X}", cfpa.rotkh_revoke).ok();
+    dump_hex!(cfpa.customer_data, 10);
+    
+
+    heprintln!("Increment the version and write back cfpa!").ok();
+    let old_version = cfpa.version;
+    cfpa.version = cfpa.version + 1;
+    cfpa.secure_fw_version += 1;
+    cfpa.ns_fw_version += 1;
+    // increment a byte of customer data (with overflow)
+    let old_data = cfpa.customer_data[0];
+    cfpa.customer_data[0] = ((1 + (cfpa.customer_data[0] as u16)) & 0xff) as u8;
+    pfr.write_cfpa(&cfpa).unwrap();
+
+    let new_cfpa = pfr.read_cfpa().unwrap();
+    heprintln!("Updated CFPA:").ok();
+    heprintln!("CFPA:").ok();
+    heprintln!("header = {:08X}", new_cfpa.header).ok();
+    heprintln!("version = {:08X}", new_cfpa.version).ok();
+    heprintln!("secureVersion = {:08X}", new_cfpa.secure_fw_version).ok();
+    heprintln!("notSecureVersion = {:08X}", new_cfpa.ns_fw_version).ok();
+    
+    heprintln!("imageKeyRevoke = {:08X}", new_cfpa.image_key_revoke).ok();
+    heprintln!("rotkhRevoke = {:08X}", new_cfpa.rotkh_revoke).ok();
+    dump_hex!(cfpa.customer_data, 10);
+
+    heprintln!("ffr block base {:08x}", pfr.flash_config.ffr_config.ffr_block_base).ok();
+    heprintln!("ffr total size {:08x}", pfr.flash_config.ffr_config.ffr_total_size).ok();
+    heprintln!("ffr page size {:08x}", pfr.flash_config.ffr_config.ffr_page_size).ok();
+    heprintln!("ffr page version {:08x}", pfr.flash_config.ffr_config.cfpa_page_version).ok();
+    heprintln!("ffr page offset {:08x}", pfr.flash_config.ffr_config.cfpa_page_offset).ok();
+
+
+    assert!( new_cfpa.version == old_version + 1 );
+    assert!( new_cfpa.secure_fw_version == cfpa.secure_fw_version );
+    assert!( new_cfpa.ns_fw_version == cfpa.ns_fw_version );
+    assert!( new_cfpa.image_key_revoke == cfpa.image_key_revoke );
+    assert!( new_cfpa.rotkh_revoke == cfpa.rotkh_revoke );
+    assert!( new_cfpa.customer_data[0] != old_data );
+
+
+    let cmpa = pfr.read_cmpa().unwrap();
+    heprintln!("\r\nCMPA:").ok();
+    heprintln!("boot_cfg = {:08X}", cmpa.boot_cfg).ok();
+    heprintln!("usb.vid = {:08X}", cmpa.usb_vid).ok();
+    heprintln!("usb.pid = {:08X}", cmpa.usb_pid).ok();
+    heprintln!("secure_boot_cfg = {:08X}", cmpa.secure_boot_cfg).ok();
+    dump_hex!(cmpa.rotkh, cmpa.rotkh.len());
+    dump_hex!(cfpa.customer_data, 10);
+    dump_hex!(cmpa.customer_data, cmpa.customer_data.len());
+
+    heprintln!("\r\nKeyStore:").ok();
+    let key_code = pfr.read_key_code(KeyType::User).unwrap();
+    dump_hex!(key_code, key_code.len());
+
+    let activation_code = pfr.read_activation_code().unwrap();
+    dump_hex!(activation_code, activation_code.len());
+
+    pfr.lock_all().unwrap();
+
+    heprintln!("done.  Must reboot to see CFPA changes take effect.").ok();
+
+    loop {
+        // done.
+    }
+}

--- a/src/drivers/clocks.rs
+++ b/src/drivers/clocks.rs
@@ -51,8 +51,8 @@ pub struct ClockRequirements {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Clocks {
-    main_clock: MainClock,
-    system_frequency: Hertz,
+    pub(crate) main_clock: MainClock,
+    pub(crate) system_frequency: Hertz,
 }
 
 impl Clocks {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub use peripherals::{
     inputmux::InputMux,
     iocon::Iocon,
     pint::Pint,
+    pfr::Pfr,
     pmc::Pmc,
     puf::Puf,
     rng::Rng,
@@ -155,6 +156,9 @@ pub struct Peripherals {
 
     /// Pin Interrupt and Pattern Match
     pub pint: Pint,
+
+    /// Protect flash region controller
+    pub pfr: Pfr,
 
     /// Power configuration
     pub pmc: Pmc,
@@ -248,6 +252,7 @@ impl From<(raw::Peripherals, rtic::Peripherals)> for Peripherals {
             inputmux: InputMux::from(p.INPUTMUX),
             iocon: Iocon::from(p.IOCON),
             pint: Pint::from(p.PINT),
+            pfr: Pfr::new(),
             pmc: Pmc::from(p.PMC),
             rng: Rng::from(p.RNG),
             rtc: Rtc::from(p.RTC),
@@ -309,6 +314,7 @@ impl From<(raw::Peripherals, raw::CorePeripherals)> for Peripherals {
             inputmux: InputMux::from(p.INPUTMUX),
             iocon: Iocon::from(p.IOCON),
             pint: Pint::from(p.PINT),
+            pfr: Pfr::new(),
             pmc: Pmc::from(p.PMC),
             rng: Rng::from(p.RNG),
             rtc: Rtc::from(p.RTC),
@@ -393,4 +399,13 @@ pub fn wait_at_least(delay_usecs: u32) {
         while target < get_cycle_count() as u64 { continue; }
     }
     while target > get_cycle_count() as u64 { continue; }
+}
+
+pub fn uuid() -> [u8; 16] {
+    const UUID: *const u8 = 0x0009_FC70 as *const u8;
+    let mut uuid: [u8; 16] = [0; 16];
+    for i in 0..16 {
+        uuid[i] = unsafe { *UUID.offset(i as isize) };
+    }
+    uuid
 }

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -31,6 +31,7 @@ pub mod gpio;
 pub mod hashcrypt;
 pub mod inputmux;
 pub mod iocon;
+pub mod pfr;
 pub mod pint;
 pub mod pmc;
 pub mod puf;

--- a/src/peripherals/pfr.rs
+++ b/src/peripherals/pfr.rs
@@ -1,0 +1,308 @@
+use core::result::Result;
+// use cortex_m_semihosting::{heprint,heprintln};
+use crate::{
+    drivers::{
+        clocks::Clocks,
+    },
+    typestates::{
+        init_state,
+    }
+};
+
+#[derive(Copy,Clone,PartialEq)]
+pub enum KeyType {
+    Sbkek = 0x00,
+    User = 0x01,
+    Uds  = 0x02,
+    PrinceRegion0 = 0x03,
+    PrinceRegion1 = 0x04,
+    PrinceRegion2 = 0x05,
+}
+
+#[derive(Copy,Clone)]
+#[repr(C)]
+struct IvCodePrinceRegion {
+    keycode_header: u32,
+    reserved: [u8; 52],
+}
+
+#[derive(Copy,Clone)]
+#[repr(C)]
+pub struct Cfpa {
+    pub header: u32,
+    pub version: u32,
+    pub secure_fw_version: u32,
+    pub ns_fw_version: u32,
+    pub image_key_revoke: u32,
+
+    reserved0: [u8; 4],
+
+    pub rotkh_revoke: u32,
+    vendor_usage: u32,
+    pub dcfg_ns_pin: u32,
+    pub dcfg_ns_dflt: u32,
+    enable_fa_mode: u32,
+
+    reserved1: [u8; 4],
+    // 12 * 4
+
+    // + (4 + 52) * 3
+    iv_code_prince_region: [IvCodePrinceRegion; 3],
+
+    // + 40 + 224 + 32
+    reserved2: [u8; 40],
+    pub customer_data: [u8; 224],
+    sha256: [u8; 32]
+}
+
+#[derive(Copy,Clone)]
+#[repr(C)]
+pub struct Cmpa {
+    pub boot_cfg: u32,
+    pub spi_flash_cfg: u32,
+    pub usb_vid: u16,
+    pub usb_pid: u16,
+    pub sdio_cfg: u32,
+    pub dcfg_pin: u32,
+    pub dcfg_dflt: u32,
+    pub dap_vendor_usage: u32,
+    pub secure_boot_cfg: u32,
+    pub prince_base_addr: u32,
+    pub prince_sr: [u32; 3],
+    reserved0: [u8; 32],
+
+    pub rotkh: [u8; 32],
+    reserved1: [u8; 144],
+
+    pub customer_data: [u8; 224],
+    sha256: [u8; 32]
+}
+
+
+// This compile time guarantees that Cmpa and Cfpa are 512 bytes.
+#[allow(unreachable_code)]
+fn _compile_time_assert() { 
+    unsafe {
+        core::mem::transmute::<Cmpa, [u8; 512]>(panic!());
+        core::mem::transmute::<Cfpa, [u8; 512]>(panic!());
+    }
+ }
+
+// #define BOOTLOADER_API_TREE_POINTER (bootloader_tree_t*) 0x130010f0
+#[repr(C)]
+struct BootloaderTree {
+
+    // All this does is a soft reset.
+    run_bootloader: extern "C" fn(arg: &u32) -> (),
+
+    version: u32,
+    copyright: *const char,
+    reserved0: u32,
+
+    flash_driver: &'static FlashDriverInterface,
+
+    // don't need these.
+    reserved_kb_interface: u32,
+    reserved1: [u32; 4],
+    reserved_skboot_authenticate_interface: u32,
+}
+
+#[repr(C)]
+struct FlashDriverInterface {
+    version: u32,  
+    flash_init: unsafe extern "C" fn(config: &mut FlashConfig) -> u32,
+    flash_erase: unsafe extern "C" fn(config: &mut FlashConfig, start: u32, length_in_bytes: u32, key: u32) -> u32,
+    flash_program: unsafe extern "C" fn(config: &mut FlashConfig, start: u32, src: *const u8, length_in_bytes: u32) -> u32,
+    flash_verify_erase: unsafe extern "C" fn(config: &mut FlashConfig, start: u32, length_in_bytes: u32) -> u32,
+    flash_verify_program: unsafe extern "C" fn(config: &mut FlashConfig,
+                                        start: u32, length_in_bytes: u32,
+                                        expected_data: *const u8,
+                                        failed_address: &mut u32,
+                                        failed_data: &mut u32) -> u32,
+
+    flash_get_property: unsafe extern "C" fn(config: &mut FlashConfig, tag: u32, value: &mut u32) -> u32,
+    reserved: [u32; 3],
+
+    ffr_init: unsafe extern "C" fn(config: &mut FlashConfig) -> u32,
+    ffr_lock_all: unsafe extern "C" fn(config: &mut FlashConfig) -> u32,
+    ffr_cust_factory_page_write: unsafe extern "C" fn(config: &mut FlashConfig, page_data: *const u8, seal_part: bool) -> u32,
+    ffr_get_uuid: unsafe extern "C" fn(config: &mut FlashConfig, uuid: *mut u8) -> u32,
+    ffr_get_customer_data: unsafe extern "C" fn(config: &mut FlashConfig, pData: *mut u8, offset: u32, len: u32) -> u32,
+
+    // TODO
+    ffr_keystore_write: unsafe extern "C" fn(config: &mut FlashConfig, ) -> u32,
+    ffr_keystore_get_ac: unsafe extern "C" fn(config: &mut FlashConfig, activation_code: *mut u8) -> u32,
+    ffr_keystore_get_kc: unsafe extern "C" fn(config: &mut FlashConfig, keycode: *mut u8, key_index: u32) -> u32,
+
+    ffr_infield_page_write: unsafe extern "C" fn(config: &mut FlashConfig, page_data: *const u8, valid_len: u32) -> u32,
+    ffr_get_customer_infield_data: unsafe extern "C" fn(config: &mut FlashConfig, page_data: *mut u8, offset: u32, len: u32) -> u32,
+}
+
+#[repr(C)]
+pub struct FlashFfrConfig {
+    pub ffr_block_base: u32,
+    pub ffr_total_size: u32,
+    pub ffr_page_size: u32,
+    pub cfpa_page_version: u32,
+    pub cfpa_page_offset: u32,
+}
+
+#[repr(C)]
+pub struct FlashModeConfig {
+    sys_freq_in_mhz: u32,
+    single_word_mode: u32,
+    write_mode: u32,
+    read_mode: u32,
+}
+
+#[repr(C)]
+pub struct FlashConfig {
+    pflash_block_base: u32,
+    pflash_total_size: u32,
+    pflash_block_count: u32,
+    pflash_page_size: u32,
+
+    pflash_sector_size: u32,
+
+
+    pub ffr_config: FlashFfrConfig,
+    pub mode_config: FlashModeConfig,
+}
+
+impl FlashConfig {
+    fn new(system_clock_freq_in_mhz: u32) -> FlashConfig {
+        let flash_ffr_config = FlashFfrConfig {
+            ffr_block_base: 0,
+            ffr_total_size: 0,
+            ffr_page_size: 0,
+            cfpa_page_version: 0,
+            cfpa_page_offset: 0,
+        };
+        let flash_mode_config = FlashModeConfig {
+            sys_freq_in_mhz: system_clock_freq_in_mhz,
+            single_word_mode: 0,
+            write_mode: 0,
+            read_mode: 0,
+        };
+        FlashConfig {
+            pflash_block_base: 0,
+            pflash_total_size: 0,
+            pflash_block_count: 0,
+            pflash_page_size: 0,
+            pflash_sector_size: 0,
+            ffr_config: flash_ffr_config,
+            mode_config: flash_mode_config,
+        }
+    }
+}
+
+pub struct Pfr<State = init_state::Unknown> {
+    pub flash_config: FlashConfig,
+    pub _state: State,
+}
+impl<State> Pfr<State> {
+    fn bootloader_api_tree() -> &'static mut BootloaderTree {
+        unsafe { core::mem::transmute(0x130010f0u32 as *const ()) }
+    }
+    fn check_error(err: u32) -> Result<(), u32> {
+        if err == 0 {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+}
+impl Pfr{
+    pub fn new() -> Self {
+        Self {
+            flash_config: FlashConfig::new(0),
+            _state: init_state::Unknown,
+        }
+    }
+
+    pub fn enabled(mut self, clock_config: &Clocks) -> Result<Pfr<init_state::Enabled>, u32> {
+
+        self.flash_config = FlashConfig::new(clock_config.system_frequency.0/1000_000);
+
+        let flash_init = Self::bootloader_api_tree().flash_driver.flash_init;
+        let ffr_init = Self::bootloader_api_tree().flash_driver.ffr_init;
+
+        Self::check_error( unsafe { flash_init(&mut self.flash_config) } )?;
+        Self::check_error( unsafe { ffr_init(&mut self.flash_config) } )?;
+
+        Ok(Pfr{
+            flash_config: self.flash_config,
+            _state: init_state::Enabled(())
+        })
+    }
+}
+
+impl Pfr <init_state::Enabled> {
+
+    pub fn read_cmpa(&mut self) -> Result<Cmpa, u32> {
+        let mut cmpa_bytes = [0u8; 512];
+
+        let ffr_get_customer_data = Self::bootloader_api_tree().flash_driver.ffr_get_customer_data;
+
+        Self::check_error(unsafe { ffr_get_customer_data(&mut self.flash_config, cmpa_bytes.as_mut_ptr(), 0, 512) })?;
+        // heprintln!("cfpa:").ok();
+        // dump_hex!(cfpa_bytes, 512);
+
+        let cmpa: &Cmpa = unsafe{ core::mem::transmute(cmpa_bytes.as_ptr()) };
+
+        Ok(*cmpa)
+    }
+
+    pub fn read_cfpa(&mut self) -> Result<Cfpa, u32> {
+        let mut cfpa_bytes = [0u8; 512];
+
+        let ffr_get_customer_infield_data = Self::bootloader_api_tree().flash_driver.ffr_get_customer_infield_data;
+
+        Self::check_error( unsafe { ffr_get_customer_infield_data(&mut self.flash_config, cfpa_bytes.as_mut_ptr(), 0, 512) })?;
+        // heprintln!("cfpa:").ok();
+        // dump_hex!(cfpa_bytes, 512);
+
+        let cfpa: &Cfpa = unsafe{ core::mem::transmute(cfpa_bytes.as_ptr()) };
+
+        Ok(*cfpa)
+    }
+
+    pub fn write_cfpa(&mut self, cfpa: &Cfpa) -> Result<(), u32> {
+
+        let ffr_infield_page_write = Self::bootloader_api_tree().flash_driver.ffr_infield_page_write;
+        let cfpa_bytes: *const u8 = unsafe{ core::mem::transmute( cfpa as *const Cfpa)};
+        Self::check_error( 
+            unsafe{ ffr_infield_page_write (&mut self.flash_config, cfpa_bytes, 512) }
+        )?;
+        Ok(())
+    }
+
+    pub fn read_key_code(&mut self, key_type: KeyType) -> Result<[u8; 52], u32> {
+        let mut bytes = [0u8; 52];
+        let ffr_keystore_get_kc = Self::bootloader_api_tree().flash_driver.ffr_keystore_get_kc;
+
+        Self::check_error( 
+            unsafe{ ffr_keystore_get_kc(&mut self.flash_config, bytes.as_mut_ptr(), key_type as u32) }
+        )?;
+
+        Ok(bytes)
+    }
+
+    pub fn read_activation_code(&mut self) -> Result<[u8; 1192], u32> {
+        let mut ac = [0u8; 1192];
+        let ffr_keystore_get_ac = Self::bootloader_api_tree().flash_driver.ffr_keystore_get_ac;
+        Self::check_error(
+            unsafe { ffr_keystore_get_ac(&mut self.flash_config, ac.as_mut_ptr()) }
+        )?;
+
+        Ok(ac)
+    }
+
+    /// Set write protection to PFR pages.  Lasts until next power on reset.
+    pub fn lock_all(&mut self) -> Result<(), u32> {
+        let ffr_lock_all= Self::bootloader_api_tree().flash_driver.ffr_lock_all;
+        Self::check_error( unsafe { ffr_lock_all(&mut self.flash_config) } )?;
+        Ok(())
+    }
+
+}


### PR DESCRIPTION
Adds initial pfr support that is based on the flash API baked into the boot rom.

Running into an issue where the CFPA write doesn't seem to persist after boot unless the version is incremented more than the last time it was incremented (just incrementing by 1 doesn't seem to persist).  Still looking into it but wanted to get something ready to merge at least.