### PR TITLE
add method for reading cfpa with expected behavior

### DIFF
--- a/src/peripherals/pfr.rs
+++ b/src/peripherals/pfr.rs
@@ -253,6 +253,13 @@ impl Pfr <init_state::Enabled> {
         Ok(*cmpa)
     }
 
+    /// Get a readonly static reference to the customer data in CMPA.
+    pub fn cmpa_customer_data(&mut self) -> &'static [u8] {
+        let cmpa_ptr = (0x9E500) as *const u8;
+        let slice = unsafe { core::slice::from_raw_parts(cmpa_ptr, 224) };
+        slice
+    }
+
     /// Keeping here for reference, but this sometimes returns unexpected old versions of the CFPA page that
     /// are not seen on scratch, ping, or pong pages.
     /// Findings:


### PR DESCRIPTION
Workaround to fix the issue I was seeing with the bootrom api method for reading the CFPA was returning old versions unexpectedly.  Instead, re-implement what I would expect it to do.