### PR TITLE
Update flash boundary to be on start of last prince region (128K tota…

### DIFF
--- a/src/drivers/flash.rs
+++ b/src/drivers/flash.rs
@@ -238,7 +238,7 @@ enum FlashCommands {
 
 #[cfg(feature = "littlefs")]
 // const BASE_OFFSET: usize = 0x0007_d000;
-const BASE_OFFSET: usize = 0x0008_9800;
+const BASE_OFFSET: usize = 0x7_d800;
 
 #[cfg(feature = "littlefs")]
 impl littlefs2::driver::Storage for FlashGordon {
@@ -249,7 +249,7 @@ impl littlefs2::driver::Storage for FlashGordon {
     // currently: 230K -> 230*2 = 460
     // const BLOCK_COUNT: usize = 400;
     // const BLOCK_COUNT: usize = 200;
-    const BLOCK_COUNT: usize = 160;
+    const BLOCK_COUNT: usize = 256;
     // no wear-leveling for now
     const BLOCK_CYCLES: isize = -1;
     // const BASE_OFFSET: usize = 0x0006_4000;


### PR DESCRIPTION
Move the filesystem boundary to the last 128K (taking up 502K - 630K of flash), which is aligned with the last prince region.